### PR TITLE
Register validation fix, template email

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/config/EmailConfig.java
+++ b/apps/backend/src/main/java/com/intranet/backend/config/EmailConfig.java
@@ -46,11 +46,19 @@ public class EmailConfig {
         props.put("mail.smtp.auth", "true");
         props.put("mail.smtp.starttls.enable", "true");
         props.put("mail.smtp.ssl.trust", host);
-        props.put("mail.debug", "true"); // Para depuração
+
+        // Adicionar propriedades para melhorar a compatibilidade com o Gmail
+        props.put("mail.smtp.allow8bitmime", "true");
+        props.put("mail.smtps.allow8bitmime", "true");
+        props.put("mail.mime.charset", "UTF-8");
+        props.put("mail.mime.encodefilename", "true");
+        props.put("mail.mime.encodeparameters", "true");
+
+        // Habilitar debugging de SMTP para diagnóstico
+        props.put("mail.debug", "true");
 
         return mailSender;
     }
-
     // Template resolver HTML para emails
     @Bean
     public ITemplateResolver emailTemplateResolver() {

--- a/apps/backend/src/main/java/com/intranet/backend/service/EmailService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/EmailService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
+import java.io.UnsupportedEncodingException;
+
 @Service
 @RequiredArgsConstructor
 public class EmailService {
@@ -55,7 +57,7 @@ public class EmailService {
             // Enviar o email
             mailSender.send(message);
             logger.info("Email de redefinição de senha enviado para: {}", to);
-        } catch (MessagingException e) {
+        } catch (MessagingException | UnsupportedEncodingException e) {
             logger.error("Erro ao enviar email de redefinição de senha para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de redefinição de senha", e);
         }
@@ -83,7 +85,7 @@ public class EmailService {
 
             mailSender.send(message);
             logger.info("Email de confirmação de redefinição de senha enviado para: {}", to);
-        } catch (MessagingException e) {
+        } catch (MessagingException | UnsupportedEncodingException e) {
             logger.error("Erro ao enviar email de confirmação para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de confirmação", e);
         }
@@ -112,7 +114,7 @@ public class EmailService {
 
             mailSender.send(message);
             logger.info("Email de verificação enviado para: {}", to);
-        } catch (MessagingException e) {
+        } catch (MessagingException | UnsupportedEncodingException e) {
             logger.error("Erro ao enviar email de verificação para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de verificação", e);
         }
@@ -140,7 +142,7 @@ public class EmailService {
 
             mailSender.send(message);
             logger.info("Email de aprovação de conta enviado para: {}", to);
-        } catch (MessagingException e) {
+        } catch (MessagingException | UnsupportedEncodingException e) {
             logger.error("Erro ao enviar email de aprovação de conta para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de aprovação de conta", e);
         }

--- a/apps/backend/src/main/java/com/intranet/backend/service/EmailService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/EmailService.java
@@ -28,14 +28,10 @@ public class EmailService {
     public void sendPasswordResetEmail(String to, String token, String name) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
-            // Use o charset UTF-8 e especifique que é multipart
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            // Configuração simples sem multipart inicialmente
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
 
-            // Adicionar logo como uma imagem embutida
-            helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
-
-            // Definir os cabeçalhos corretos para HTML
-            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
+            helper.setFrom("desenvolvimento@lavorato.com.br");
             helper.setTo(to);
             helper.setSubject("Redefinição de Senha - Lavorato Saúde Integrada");
 
@@ -51,13 +47,10 @@ public class EmailService {
             // Definir o conteúdo como HTML
             helper.setText(htmlContent, true);
 
-            // Adicionar cabeçalho Content-Type explícito
-            message.setHeader("Content-Type", "text/html; charset=UTF-8");
-
             // Enviar o email
             mailSender.send(message);
             logger.info("Email de redefinição de senha enviado para: {}", to);
-        } catch (MessagingException | UnsupportedEncodingException e) {
+        } catch (MessagingException e) {
             logger.error("Erro ao enviar email de redefinição de senha para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de redefinição de senha", e);
         }
@@ -67,10 +60,9 @@ public class EmailService {
     public void sendPasswordResetConfirmationEmail(String to, String name) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
 
-            helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
-            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
+            helper.setFrom("desenvolvimento@lavorato.com.br");
             helper.setTo(to);
             helper.setSubject("Senha Redefinida com Sucesso - Lavorato Saúde Integrada");
 
@@ -81,11 +73,9 @@ public class EmailService {
             String htmlContent = templateEngine.process("email/reset-password-confirmation", context);
             helper.setText(htmlContent, true);
 
-            message.setHeader("Content-Type", "text/html; charset=UTF-8");
-
             mailSender.send(message);
             logger.info("Email de confirmação de redefinição de senha enviado para: {}", to);
-        } catch (MessagingException | UnsupportedEncodingException e) {
+        } catch (MessagingException e) {
             logger.error("Erro ao enviar email de confirmação para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de confirmação", e);
         }
@@ -95,10 +85,9 @@ public class EmailService {
     public void sendEmailVerification(String to, String token, String name) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
 
-            helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
-            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
+            helper.setFrom("desenvolvimento@lavorato.com.br");
             helper.setTo(to);
             helper.setSubject("Verifique seu Email - Lavorato Saúde Integrada");
 
@@ -110,11 +99,9 @@ public class EmailService {
             String htmlContent = templateEngine.process("email/email-verification", context);
             helper.setText(htmlContent, true);
 
-            message.setHeader("Content-Type", "text/html; charset=UTF-8");
-
             mailSender.send(message);
             logger.info("Email de verificação enviado para: {}", to);
-        } catch (MessagingException | UnsupportedEncodingException e) {
+        } catch (MessagingException e) {
             logger.error("Erro ao enviar email de verificação para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de verificação", e);
         }
@@ -124,10 +111,9 @@ public class EmailService {
     public void sendAccountApprovalEmail(String to, String name) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
 
-            helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
-            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
+            helper.setFrom("desenvolvimento@lavorato.com.br");
             helper.setTo(to);
             helper.setSubject("Conta Aprovada - Lavorato Saúde Integrada");
 
@@ -138,11 +124,9 @@ public class EmailService {
             String htmlContent = templateEngine.process("email/account-approval", context);
             helper.setText(htmlContent, true);
 
-            message.setHeader("Content-Type", "text/html; charset=UTF-8");
-
             mailSender.send(message);
             logger.info("Email de aprovação de conta enviado para: {}", to);
-        } catch (MessagingException | UnsupportedEncodingException e) {
+        } catch (MessagingException e) {
             logger.error("Erro ao enviar email de aprovação de conta para: {}", to, e);
             throw new RuntimeException("Erro ao enviar email de aprovação de conta", e);
         }

--- a/apps/backend/src/main/java/com/intranet/backend/service/EmailService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/EmailService.java
@@ -26,21 +26,33 @@ public class EmailService {
     public void sendPasswordResetEmail(String to, String token, String name) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
+            // Use o charset UTF-8 e especifique que é multipart
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
+            // Adicionar logo como uma imagem embutida
             helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
 
-            helper.setFrom("desenvolvimento@lavorato.com.br");
+            // Definir os cabeçalhos corretos para HTML
+            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
             helper.setTo(to);
             helper.setSubject("Redefinição de Senha - Lavorato Saúde Integrada");
 
+            // Preparar o contexto do template
             Context context = new Context();
             context.setVariable("token", token);
             context.setVariable("name", name);
+            context.setVariable("loginUrl", "https://lavorato.app.br/auth/login");
 
+            // Processar o template
             String htmlContent = templateEngine.process("email/reset-password", context);
+
+            // Definir o conteúdo como HTML
             helper.setText(htmlContent, true);
 
+            // Adicionar cabeçalho Content-Type explícito
+            message.setHeader("Content-Type", "text/html; charset=UTF-8");
+
+            // Enviar o email
             mailSender.send(message);
             logger.info("Email de redefinição de senha enviado para: {}", to);
         } catch (MessagingException e) {
@@ -56,16 +68,18 @@ public class EmailService {
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
             helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
-
-            helper.setFrom("desenvolvimento@lavorato.com.br");
+            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
             helper.setTo(to);
             helper.setSubject("Senha Redefinida com Sucesso - Lavorato Saúde Integrada");
 
             Context context = new Context();
             context.setVariable("name", name);
+            context.setVariable("loginUrl", "https://lavorato.app.br/auth/login");
 
             String htmlContent = templateEngine.process("email/reset-password-confirmation", context);
             helper.setText(htmlContent, true);
+
+            message.setHeader("Content-Type", "text/html; charset=UTF-8");
 
             mailSender.send(message);
             logger.info("Email de confirmação de redefinição de senha enviado para: {}", to);
@@ -82,17 +96,19 @@ public class EmailService {
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
             helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
-
-            helper.setFrom("desenvolvimento@lavorato.com.br");
+            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
             helper.setTo(to);
             helper.setSubject("Verifique seu Email - Lavorato Saúde Integrada");
 
             Context context = new Context();
             context.setVariable("token", token);
             context.setVariable("name", name);
+            context.setVariable("loginUrl", "https://lavorato.app.br/auth/login");
 
             String htmlContent = templateEngine.process("email/email-verification", context);
             helper.setText(htmlContent, true);
+
+            message.setHeader("Content-Type", "text/html; charset=UTF-8");
 
             mailSender.send(message);
             logger.info("Email de verificação enviado para: {}", to);
@@ -109,16 +125,18 @@ public class EmailService {
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
             helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
-
-            helper.setFrom("desenvolvimento@lavorato.com.br");
+            helper.setFrom("desenvolvimento@lavorato.com.br", "Lavorato Saúde Integrada");
             helper.setTo(to);
             helper.setSubject("Conta Aprovada - Lavorato Saúde Integrada");
 
             Context context = new Context();
             context.setVariable("name", name);
+            context.setVariable("loginUrl", "https://lavorato.app.br/auth/login");
 
             String htmlContent = templateEngine.process("email/account-approval", context);
             helper.setText(htmlContent, true);
+
+            message.setHeader("Content-Type", "text/html; charset=UTF-8");
 
             mailSender.send(message);
             logger.info("Email de aprovação de conta enviado para: {}", to);

--- a/apps/backend/src/main/java/com/intranet/backend/validation/LavoratoEmailValidator.java
+++ b/apps/backend/src/main/java/com/intranet/backend/validation/LavoratoEmailValidator.java
@@ -5,8 +5,6 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class LavoratoEmailValidator implements ConstraintValidator<LavoratoEmail, String> {
 
-    private static final String ALLOWED_DOMAIN = "@lavorato.com.br";
-
     @Override
     public void initialize(LavoratoEmail constraintAnnotation) {
         //Nada para iniciar

--- a/apps/backend/src/main/resources/templates/email/account-approval.html
+++ b/apps/backend/src/main/resources/templates/email/account-approval.html
@@ -41,7 +41,7 @@
 <body>
 <div class="container">
     <div class="header">
-        <img src="cid:logo" alt="Lavorato Saúde Integrada" />
+        <img src="cid:logo" alt="Lavorato Saúde Integrada" style="max-width: 200px; height: auto;" />
         <h1>Conta Aprovada</h1>
     </div>
     <div class="content">

--- a/apps/backend/src/main/resources/templates/email/account-approval.html
+++ b/apps/backend/src/main/resources/templates/email/account-approval.html
@@ -41,7 +41,6 @@
 <body>
 <div class="container">
     <div class="header">
-        <img src="cid:logo" alt="Lavorato Saúde Integrada" style="max-width: 200px; height: auto;" />
         <h1>Conta Aprovada</h1>
     </div>
     <div class="content">

--- a/apps/backend/src/main/resources/templates/email/account-approval.html
+++ b/apps/backend/src/main/resources/templates/email/account-approval.html
@@ -48,7 +48,7 @@
         <p>Temos o prazer de informar que sua conta na Lavorato Saúde Integrada foi aprovada pelo administrador.</p>
         <p>Agora você pode acessar nosso sistema normalmente.</p>
         <div style="text-align: center; margin: 30px 0;">
-            <a th:href="@{${loginUrl}}" class="button">Acessar o Sistema</a>
+            <a href="https://dev.lavorato.app.br/auth/login" class="button">Acessar o Sistema</a>
         </div>
         <p>Se você tiver alguma dúvida, entre em contato conosco.</p>
         <p>Atenciosamente,<br/>Equipe Lavorato Saúde Integrada</p>

--- a/apps/backend/src/main/resources/templates/email/email-verification.html
+++ b/apps/backend/src/main/resources/templates/email/email-verification.html
@@ -4,164 +4,83 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Verifique seu Email</title>
-  <style type="text/css">
-    /* Reset de estilos para clientes de email */
-    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
-    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
-    img { -ms-interpolation-mode: bicubic; }
-
-    /* Reset para alguns clientes móveis */
-    body { margin: 0 !important; padding: 0 !important; width: 100% !important; }
-
-    /* Oculta elementos para clientes móveis */
-    .mobile-hidden { display: none !important; }
-
-    /* Estilos básicos */
+  <style>
     body {
-      margin: 0;
-      padding: 0;
       font-family: Arial, Helvetica, sans-serif;
       font-size: 16px;
       line-height: 1.6;
       color: #333333;
+      margin: 0;
+      padding: 0;
     }
-
-    /* Contêiner para o email */
-    .email-container {
+    .container {
       max-width: 600px;
       margin: 0 auto;
-      background-color: #ffffff;
+      padding: 20px;
     }
-
-    /* Cabeçalho */
     .header {
       background-color: #2ea6b8;
-      padding: 30px 20px;
+      color: #ffffff;
+      padding: 20px;
       text-align: center;
     }
-
     .header h1 {
       margin: 0;
-      color: #ffffff;
       font-size: 24px;
-      font-weight: bold;
     }
-
-    /* Conteúdo do email */
     .content {
-      padding: 30px 20px;
-    }
-
-    /* Código de verificação */
-    .verification-code {
       padding: 20px;
-      margin: 25px 0;
-      font-size: 32px;
+      background-color: #ffffff;
+    }
+    .verification-code {
+      padding: 15px;
+      margin: 20px 0;
+      font-size: 28px;
       font-weight: bold;
-      letter-spacing: 10px;
+      letter-spacing: 5px;
       text-align: center;
       color: #2ea6b8;
-      background-color: #f9f9f9;
-      border-radius: 5px;
-      border: 1px solid #eaeaea;
+      background-color: #f5f5f5;
+      border-radius: 4px;
     }
-
-    /* Rodapé */
     .footer {
       padding: 20px;
       text-align: center;
-      color: #666666;
       font-size: 12px;
-      background-color: #f9f9f9;
-      border-top: 1px solid #eaeaea;
+      color: #666666;
+      background-color: #f5f5f5;
     }
-
-    /* Links */
-    a {
-      color: #2ea6b8;
-      text-decoration: none;
-    }
-
-    /* Botão para link */
     .button {
       display: inline-block;
       padding: 10px 20px;
-      margin: 20px 0;
       background-color: #2ea6b8;
-      color: #ffffff !important;
+      color: #ffffff;
       text-decoration: none;
       border-radius: 4px;
-      font-weight: bold;
-    }
-
-    /* Estilos responsivos */
-    @media screen and (max-width: 600px) {
-      .email-container {
-        width: 100% !important;
-      }
-      .verification-code {
-        font-size: 24px;
-        letter-spacing: 8px;
-      }
-    }
-
-    @media screen and (max-width: 400px) {
-      .verification-code {
-        font-size: 20px;
-        letter-spacing: 5px;
-        padding: 15px 10px;
-      }
+      margin: 20px 0;
     }
   </style>
 </head>
 <body>
-<table border="0" cellpadding="0" cellspacing="0" width="100%">
-  <tr>
-    <td align="center" valign="top">
-      <table class="email-container" border="0" cellpadding="0" cellspacing="0" width="600">
-        <!-- Cabeçalho -->
-        <tr>
-          <td class="header" align="center">
-            <img src="cid:logo" alt="Lavorato Saúde Integrada" style="max-width: 200px; height: auto;" />
-            <h1>Lavorato Saúde Integrada</h1>
-          </td>
-        </tr>
+<div class="container">
+  <div class="header">
+    <h1>Lavorato Saúde Integrada</h1>
+  </div>
+  <div class="content">
+    <p>Olá, <strong th:text="${name}">Usuário</strong>!</p>
 
-        <!-- Conteúdo -->
-        <tr>
-          <td class="content">
-            <p>Olá, <strong th:text="${name}">Usuário</strong>!</p>
+    <p>Obrigado por se registrar. Por favor, use o código abaixo para ativar sua conta.</p>
 
-            <p>Obrigado por se registrar. Por favor, verifique seu email para ativar sua conta.</p>
+    <div class="verification-code" th:text="${token}">123456</div>
 
-            <p>Seu código de verificação é:</p>
+    <p>Este código é válido por 24 horas. Após este período, você precisará solicitar um novo código.</p>
 
-            <div class="verification-code" th:text="${token}">123456</div>
-
-            <p>Este código é válido por 24 horas. Após este período, você precisará solicitar um novo código.</p>
-
-            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-              <tr>
-                <td align="center">
-                  <a th:href="${loginUrl}" class="button">Acessar o Portal</a>
-                </td>
-              </tr>
-            </table>
-
-            <p>Atenciosamente,<br/>Equipe Lavorato Saúde Integrada</p>
-          </td>
-        </tr>
-
-        <!-- Rodapé -->
-        <tr>
-          <td class="footer">
-            <p>Este é um email automático. Por favor, não responda a este email.</p>
-            <p>&copy; 2025 Lavorato Saúde Integrada. Todos os direitos reservados.</p>
-          </td>
-        </tr>
-      </table>
-    </td>
-  </tr>
-</table>
+    <p>Atenciosamente,<br/>Equipe Lavorato Saúde Integrada</p>
+  </div>
+  <div class="footer">
+    <p>Este é um email automático. Por favor, não responda a este email.</p>
+    <p>&copy; 2025 Lavorato Saúde Integrada. Todos os direitos reservados.</p>
+  </div>
+</div>
 </body>
 </html>

--- a/apps/backend/src/main/resources/templates/email/email-verification.html
+++ b/apps/backend/src/main/resources/templates/email/email-verification.html
@@ -1,10 +1,22 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Verifique seu Email</title>
   <style type="text/css">
+    /* Reset de estilos para clientes de email */
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; }
+
+    /* Reset para alguns clientes móveis */
+    body { margin: 0 !important; padding: 0 !important; width: 100% !important; }
+
+    /* Oculta elementos para clientes móveis */
+    .mobile-hidden { display: none !important; }
+
+    /* Estilos básicos */
     body {
       margin: 0;
       padding: 0;
@@ -12,33 +24,35 @@
       font-size: 16px;
       line-height: 1.6;
       color: #333333;
-      -webkit-text-size-adjust: 100%;
-      -ms-text-size-adjust: 100%;
     }
 
+    /* Contêiner para o email */
     .email-container {
       max-width: 600px;
       margin: 0 auto;
       background-color: #ffffff;
     }
 
+    /* Cabeçalho */
     .header {
       background-color: #2ea6b8;
-      color: #ffffff;
       padding: 30px 20px;
       text-align: center;
     }
 
     .header h1 {
       margin: 0;
+      color: #ffffff;
       font-size: 24px;
       font-weight: bold;
     }
 
+    /* Conteúdo do email */
     .content {
       padding: 30px 20px;
     }
 
+    /* Código de verificação */
     .verification-code {
       padding: 20px;
       margin: 25px 0;
@@ -52,6 +66,7 @@
       border: 1px solid #eaeaea;
     }
 
+    /* Rodapé */
     .footer {
       padding: 20px;
       text-align: center;
@@ -61,37 +76,92 @@
       border-top: 1px solid #eaeaea;
     }
 
+    /* Links */
     a {
       color: #2ea6b8;
       text-decoration: none;
     }
+
+    /* Botão para link */
+    .button {
+      display: inline-block;
+      padding: 10px 20px;
+      margin: 20px 0;
+      background-color: #2ea6b8;
+      color: #ffffff !important;
+      text-decoration: none;
+      border-radius: 4px;
+      font-weight: bold;
+    }
+
+    /* Estilos responsivos */
+    @media screen and (max-width: 600px) {
+      .email-container {
+        width: 100% !important;
+      }
+      .verification-code {
+        font-size: 24px;
+        letter-spacing: 8px;
+      }
+    }
+
+    @media screen and (max-width: 400px) {
+      .verification-code {
+        font-size: 20px;
+        letter-spacing: 5px;
+        padding: 15px 10px;
+      }
+    }
   </style>
 </head>
 <body>
-<div class="email-container">
-  <div class="header">
-    <img src="cid:logo" alt="Lavorato Saúde Integrada" style="max-width: 200px; height: auto;" />
-    <h1>Lavorato Saúde Integrada</h1>
-  </div>
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td align="center" valign="top">
+      <table class="email-container" border="0" cellpadding="0" cellspacing="0" width="600">
+        <!-- Cabeçalho -->
+        <tr>
+          <td class="header" align="center">
+            <img src="cid:logo" alt="Lavorato Saúde Integrada" style="max-width: 200px; height: auto;" />
+            <h1>Lavorato Saúde Integrada</h1>
+          </td>
+        </tr>
 
-  <div class="content">
-    <p>Olá, <strong th:text="${name}">Usuário</strong>!</p>
+        <!-- Conteúdo -->
+        <tr>
+          <td class="content">
+            <p>Olá, <strong th:text="${name}">Usuário</strong>!</p>
 
-    <p>Obrigado por se registrar. Por favor, verifique seu email para ativar sua conta.</p>
+            <p>Obrigado por se registrar. Por favor, verifique seu email para ativar sua conta.</p>
 
-    <p>Seu código de verificação é:</p>
+            <p>Seu código de verificação é:</p>
 
-    <div class="verification-code" th:text="${token}">123456</div>
+            <div class="verification-code" th:text="${token}">123456</div>
 
-    <p>Este código é válido por 24 horas. Após este período, você precisará solicitar um novo código.</p>
+            <p>Este código é válido por 24 horas. Após este período, você precisará solicitar um novo código.</p>
 
-    <p>Atenciosamente,<br>Equipe Lavorato Saúde Integrada</p>
-  </div>
+            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tr>
+                <td align="center">
+                  <a th:href="${loginUrl}" class="button">Acessar o Portal</a>
+                </td>
+              </tr>
+            </table>
 
-  <div class="footer">
-    <p>Este é um email automático, por favor não responda.</p>
-    <p>&copy; 2025 Lavorato Saúde Integrada. Todos os direitos reservados.</p>
-  </div>
-</div>
+            <p>Atenciosamente,<br/>Equipe Lavorato Saúde Integrada</p>
+          </td>
+        </tr>
+
+        <!-- Rodapé -->
+        <tr>
+          <td class="footer">
+            <p>Este é um email automático. Por favor, não responda a este email.</p>
+            <p>&copy; 2025 Lavorato Saúde Integrada. Todos os direitos reservados.</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
 </body>
 </html>

--- a/apps/backend/src/main/resources/templates/email/reset-password-confirmation.html
+++ b/apps/backend/src/main/resources/templates/email/reset-password-confirmation.html
@@ -111,7 +111,6 @@
 <body>
 <div class="email-container">
     <div class="header">
-        <img src="cid:logo" alt="Lavorato Saúde Integrada" style="max-width: 200px; height: auto;" />
         <h1>Lavorato Saúde Integrada</h1>
     </div>
 

--- a/apps/backend/src/main/resources/templates/email/reset-password.html
+++ b/apps/backend/src/main/resources/templates/email/reset-password.html
@@ -105,7 +105,6 @@
 <body>
 <div class="email-container">
     <div class="header">
-        <img src="cid:logo" alt="Lavorato Saúde Integrada" style="max-width: 200px; height: auto;" />
         <h1>Lavorato Saúde Integrada</h1>
     </div>
 

--- a/apps/frontend/src/app/auth/reset-password/page.tsx
+++ b/apps/frontend/src/app/auth/reset-password/page.tsx
@@ -34,14 +34,6 @@ export default function ResetPasswordPage() {
       return false;
     }
 
-    // Verificar se o domínio é permitido
-    if (!email.endsWith("@lavorato.com.br")) {
-      toastUtil.error(
-        "Apenas emails com domínio @lavorato.com.br são permitidos"
-      );
-      return false;
-    }
-
     return true;
   };
 

--- a/apps/frontend/src/components/profile/ProfileEdit.tsx
+++ b/apps/frontend/src/components/profile/ProfileEdit.tsx
@@ -20,17 +20,6 @@ export const ProfileEdit: React.FC<ProfileEditProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [emailError, setEmailError] = useState("");
 
-  // Validar domínio de e-mail sempre que o e-mail mudar
-  React.useEffect(() => {
-    if (email && !email.endsWith("@lavorato.com.br")) {
-      setEmailError(
-        "Apenas emails com domínio @lavorato.com.br são permitidos"
-      );
-    } else {
-      setEmailError("");
-    }
-  }, [email]);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 

--- a/apps/frontend/src/context/AuthContext.tsx
+++ b/apps/frontend/src/context/AuthContext.tsx
@@ -121,12 +121,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       return;
     }
 
-    if (!data.email.endsWith("@lavorato.com.br")) {
-      toastUtil.error(
-        "Apenas emails com domínio @lavorato.com.br são permitidos"
-      );
-      return;
-    }
+    // if (!data.email.endsWith("@lavorato.com.br")) {
+    //   toastUtil.error(
+    //     "Apenas emails com domínio @lavorato.com.br são permitidos"
+    //   );
+    //   return;
+    // }
 
     const loadingToastId = toastUtil.loading("Criando sua conta...");
 
@@ -183,12 +183,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       return;
     }
 
-    if (!email.endsWith("@lavorato.com.br")) {
-      toastUtil.error(
-        "Apenas emails com domínio @lavorato.com.br são permitidos"
-      );
-      return;
-    }
+    // if (!email.endsWith("@lavorato.com.br")) {
+    //   toastUtil.error(
+    //     "Apenas emails com domínio @lavorato.com.br são permitidos"
+    //   );
+    //   return;
+    // }
 
     const loadingToastId = toastUtil.loading("Enviando solicitação...");
 


### PR DESCRIPTION
This pull request introduces several updates to the email handling logic and templates across the backend and frontend. Key changes include improving email compatibility and formatting, simplifying email sending logic, and removing domain-specific email validation. Below is a breakdown of the most significant changes:

### Backend Email Configuration and Service Updates:

* Enhanced email compatibility by adding properties for better Gmail support, such as `mail.mime.charset` and `mail.mime.encodeparameters`, in `EmailConfig.java`. Debugging for SMTP was also explicitly enabled.
* Simplified email sending logic in `EmailService.java` by removing multipart configurations and inline logo attachments. Added a `loginUrl` variable to email templates for dynamic URL generation. [[1]](diffhunk://#diff-54d72138e49be71bd1d8fa85d656ca0dad0afec80cbd606ca66d9634752e1b4bL29-R50) [[2]](diffhunk://#diff-54d72138e49be71bd1d8fa85d656ca0dad0afec80cbd606ca66d9634752e1b4bL56-R71) [[3]](diffhunk://#diff-54d72138e49be71bd1d8fa85d656ca0dad0afec80cbd606ca66d9634752e1b4bL82-R88) [[4]](diffhunk://#diff-54d72138e49be71bd1d8fa85d656ca0dad0afec80cbd606ca66d9634752e1b4bR97) [[5]](diffhunk://#diff-54d72138e49be71bd1d8fa85d656ca0dad0afec80cbd606ca66d9634752e1b4bL109-R122)

### Email Template Adjustments:

* Removed inline logo references and improved styling consistency across email templates, including `account-approval.html`, `email-verification.html`, `reset-password.html`, and `reset-password-confirmation.html`. Updated the `loginUrl` in templates to a hardcoded URL for simplicity. [[1]](diffhunk://#diff-9a18f54a1b95178aa418b748fa1b3cb323d47792db16be0b30360975e4db838cL44-R51) [[2]](diffhunk://#diff-e35f465303778bfbf7616d6a9d51c40e90c9e3cdae6ce17d6a5a91e8353d7f84L4-R81) [[3]](diffhunk://#diff-7546e2e9b940149632aa9939bd8f4e7d1a2c3ef637d8c710245ee0870ffdcee0L114) [[4]](diffhunk://#diff-2c4569645b99d80477e0fb640efad18a05274554fe5c12ba5ba03d69f13b405bL108)

### Removal of Domain-Specific Validation:

* Eliminated the restriction requiring emails to have the `@lavorato.com.br` domain in both backend validation (`LavoratoEmailValidator.java`) and frontend components, including the reset password page, profile edit form, and authentication context. [[1]](diffhunk://#diff-0159ec7c1e40cf7f58cd1009b7ff2ba4eff16ecf997af0103a5bcdd356820150L8-L9) [[2]](diffhunk://#diff-dde6c176108447965757620c6598dc772fbe884c1c6417fcb57cd091f7263377L37-L44) [[3]](diffhunk://#diff-2ae146ded2ed1b63a4cb567d226cc16345125ea3f6fc7b683ba432cd8784102dL23-L33) [[4]](diffhunk://#diff-b59d93265c9780edb89667b71df9b88581686a2d1f468d503e1d2dbec6d1009eL124-R129) [[5]](diffhunk://#diff-b59d93265c9780edb89667b71df9b88581686a2d1f468d503e1d2dbec6d1009eL186-R191)