### PR TITLE
validation: correções do micro serviço de pacientes, guias e fichas

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/controllers/FichaController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/FichaController.java
@@ -1,0 +1,167 @@
+package com.intranet.backend.controllers;
+
+import com.intranet.backend.dto.*;
+import com.intranet.backend.service.FichaService;
+import com.intranet.backend.util.ResponseUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/fichas")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('ficha:read')")
+public class FichaController {
+
+    private static final Logger logger = LoggerFactory.getLogger(FichaController.class);
+    private final FichaService fichaService;
+
+    @GetMapping
+    public ResponseEntity<Page<FichaSummaryDto>> getAllFichas(
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para listar todas as fichas");
+
+        Page<FichaSummaryDto> fichas = fichaService.getAllFichas(pageable);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FichaDto> getFichaById(@PathVariable UUID id) {
+        logger.info("Requisição para buscar ficha com ID: {}", id);
+
+        FichaDto ficha = fichaService.getFichaById(id);
+        return ResponseUtil.success(ficha);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('ficha:create')")
+    public ResponseEntity<FichaDto> createFicha(@Valid @RequestBody FichaCreateRequest request) {
+        logger.info("Requisição para criar nova ficha para guia: {}", request.getGuiaId());
+
+        FichaDto createdFicha = fichaService.createFicha(request);
+        return ResponseUtil.created(createdFicha);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ficha:update')")
+    public ResponseEntity<FichaDto> updateFicha(
+            @PathVariable UUID id,
+            @Valid @RequestBody FichaUpdateRequest request) {
+        logger.info("Requisição para atualizar ficha com ID: {}", id);
+
+        FichaDto updatedFicha = fichaService.updateFicha(id, request);
+        return ResponseUtil.success(updatedFicha);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ficha:delete')")
+    public ResponseEntity<Void> deleteFicha(@PathVariable UUID id) {
+        logger.info("Requisição para deletar ficha com ID: {}", id);
+
+        fichaService.deleteFicha(id);
+        return ResponseUtil.noContent();
+    }
+
+    @GetMapping("/guia/{guiaId}")
+    public ResponseEntity<List<FichaDto>> getFichasByGuiaId(@PathVariable UUID guiaId) {
+        logger.info("Requisição para buscar fichas da guia: {}", guiaId);
+
+        List<FichaDto> fichas = fichaService.getFichasByGuiaId(guiaId);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<Page<FichaSummaryDto>> getFichasByPacienteId(
+            @PathVariable UUID pacienteId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar fichas do paciente: {}", pacienteId);
+
+        Page<FichaSummaryDto> fichas = fichaService.getFichasByPacienteId(pacienteId, pageable);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/convenio/{convenioId}")
+    public ResponseEntity<Page<FichaSummaryDto>> getFichasByConvenioId(
+            @PathVariable UUID convenioId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar fichas do convênio: {}", convenioId);
+
+        Page<FichaSummaryDto> fichas = fichaService.getFichasByConvenioId(convenioId, pageable);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<FichaSummaryDto>> searchFichasByEspecialidade(
+            @RequestParam String especialidade,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar fichas por especialidade: {}", especialidade);
+
+        Page<FichaSummaryDto> fichas = fichaService.searchFichasByEspecialidade(especialidade, pageable);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/periodo/{mes}/{ano}")
+    public ResponseEntity<Page<FichaSummaryDto>> getFichasByMesEAno(
+            @PathVariable Integer mes,
+            @PathVariable Integer ano,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar fichas do período: {}/{}", mes, ano);
+
+        Page<FichaSummaryDto> fichas = fichaService.getFichasByMesEAno(mes, ano, pageable);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/usuario/{userId}")
+    public ResponseEntity<Page<FichaSummaryDto>> getFichasByUsuarioResponsavel(
+            @PathVariable UUID userId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar fichas do usuário: {}", userId);
+
+        Page<FichaSummaryDto> fichas = fichaService.getFichasByUsuarioResponsavel(userId, pageable);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/stats")
+    public ResponseEntity<Map<String, Object>> getFichasStats() {
+        logger.info("Requisição para estatísticas de fichas");
+
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("totalFichas", fichaService.countTotalFichas());
+
+        return ResponseUtil.success(stats);
+    }
+
+    @GetMapping("/guia/{guiaId}/count")
+    public ResponseEntity<Map<String, Long>> countFichasByGuia(@PathVariable UUID guiaId) {
+        logger.info("Requisição para contar fichas da guia: {}", guiaId);
+
+        long count = fichaService.countFichasByGuia(guiaId);
+        Map<String, Long> response = new HashMap<>();
+        response.put("count", count);
+
+        return ResponseUtil.success(response);
+    }
+
+    @GetMapping("/convenio/{convenioId}/count")
+    public ResponseEntity<Map<String, Long>> countFichasByConvenio(@PathVariable UUID convenioId) {
+        logger.info("Requisição para contar fichas do convênio: {}", convenioId);
+
+        long count = fichaService.countFichasByConvenio(convenioId);
+        Map<String, Long> response = new HashMap<>();
+        response.put("count", count);
+
+        return ResponseUtil.success(response);
+    }
+}

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/FichaController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/FichaController.java
@@ -46,7 +46,7 @@ public class FichaController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('ficha:create')")
+    @PreAuthorize("hasAnyAuthority('ficha:create') or hasAnyRole('ADMIN')")
     public ResponseEntity<FichaDto> createFicha(@Valid @RequestBody FichaCreateRequest request) {
         logger.info("Requisição para criar nova ficha para guia: {}", request.getGuiaId());
 
@@ -55,7 +55,7 @@ public class FichaController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ficha:update')")
+    @PreAuthorize("hasAnyAuthority('ficha:update') or hasAnyRole('ADMIN')")
     public ResponseEntity<FichaDto> updateFicha(
             @PathVariable UUID id,
             @Valid @RequestBody FichaUpdateRequest request) {
@@ -66,7 +66,7 @@ public class FichaController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ficha:delete')")
+    @PreAuthorize("hasAnyAuthority('ficha:delete') or hasAnyRole('ADMIN')")
     public ResponseEntity<Void> deleteFicha(@PathVariable UUID id) {
         logger.info("Requisição para deletar ficha com ID: {}", id);
 

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/FichaController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/FichaController.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/fichas")
 @RequiredArgsConstructor
-@PreAuthorize("hasAnyAuthority('ficha:read')")
 public class FichaController {
 
     private static final Logger logger = LoggerFactory.getLogger(FichaController.class);

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/GuiaController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/GuiaController.java
@@ -1,0 +1,179 @@
+package com.intranet.backend.controllers;
+
+import com.intranet.backend.dto.*;
+import com.intranet.backend.service.GuiaService;
+import com.intranet.backend.util.ResponseUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/guias")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('guia:read')")
+public class GuiaController {
+
+    private static final Logger logger = LoggerFactory.getLogger(GuiaController.class);
+    private final GuiaService guiaService;
+
+    @GetMapping
+    public ResponseEntity<Page<GuiaSummaryDto>> getAllGuias(
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para listar todas as guias");
+
+        Page<GuiaSummaryDto> guias = guiaService.getAllGuias(pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<GuiaDto> getGuiaById(@PathVariable UUID id) {
+        logger.info("Requisição para buscar guia com ID: {}", id);
+
+        GuiaDto guia = guiaService.getGuiaById(id);
+        return ResponseUtil.success(guia);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('guia:create')")
+    public ResponseEntity<GuiaDto> createGuia(@Valid @RequestBody GuiaCreateRequest request) {
+        logger.info("Requisição para criar nova guia para paciente: {}", request.getPacienteId());
+
+        GuiaDto createdGuia = guiaService.createGuia(request);
+        return ResponseUtil.created(createdGuia);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('guia:update')")
+    public ResponseEntity<GuiaDto> updateGuia(
+            @PathVariable UUID id,
+            @Valid @RequestBody GuiaUpdateRequest request) {
+        logger.info("Requisição para atualizar guia com ID: {}", id);
+
+        GuiaDto updatedGuia = guiaService.updateGuia(id, request);
+        return ResponseUtil.success(updatedGuia);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('guia:delete')")
+    public ResponseEntity<Void> deleteGuia(@PathVariable UUID id) {
+        logger.info("Requisição para deletar guia com ID: {}", id);
+
+        guiaService.deleteGuia(id);
+        return ResponseUtil.noContent();
+    }
+
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByPaciente(
+            @PathVariable UUID pacienteId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias do paciente: {}", pacienteId);
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasByPaciente(pacienteId, pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/convenio/{convenioId}")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByConvenio(
+            @PathVariable UUID convenioId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias do convênio: {}", convenioId);
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasByConvenio(convenioId, pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/periodo/{mes}/{ano}")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByMesEAno(
+            @PathVariable Integer mes,
+            @PathVariable Integer ano,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias do período: {}/{}", mes, ano);
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasByMesEAno(mes, ano, pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/vencidas")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasVencidas(
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias vencidas");
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasVencidas(pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/quantidade-excedida")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasComQuantidadeExcedida(
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias com quantidade excedida");
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasComQuantidadeExcedida(pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/validade")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByValidade(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias com validade entre {} e {}", startDate, endDate);
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasByValidade(startDate, endDate, pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/usuario/{userId}")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByUsuarioResponsavel(
+            @PathVariable UUID userId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias do usuário: {}", userId);
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasByUsuarioResponsavel(userId, pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/especialidade")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByEspecialidade(
+            @RequestParam String especialidade,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar guias da especialidade: {}", especialidade);
+
+        Page<GuiaSummaryDto> guias = guiaService.getGuiasByEspecialidade(especialidade, pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/{id}/fichas")
+    public ResponseEntity<Page<FichaSummaryDto>> getFichasByGuiaId(
+            @PathVariable UUID id,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar fichas da guia: {}", id);
+
+        Page<FichaSummaryDto> fichas = guiaService.getFichasByGuiaId(id, pageable);
+        return ResponseUtil.success(fichas);
+    }
+
+    @GetMapping("/stats")
+    public ResponseEntity<Map<String, Object>> getGuiasStats() {
+        logger.info("Requisição para estatísticas de guias");
+
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("totalGuias", guiaService.countTotalGuias());
+        stats.put("guiasVencidas", guiaService.countGuiasVencidas());
+        stats.put("guiasQuantidadeExcedida", guiaService.countGuiasComQuantidadeExcedida());
+
+        return ResponseUtil.success(stats);
+    }
+}

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/GuiaController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/GuiaController.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/guias")
 @RequiredArgsConstructor
-@PreAuthorize("hasAnyAuthority('guia:read')")
 public class GuiaController {
 
     private static final Logger logger = LoggerFactory.getLogger(GuiaController.class);
@@ -47,7 +46,7 @@ public class GuiaController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('guia:create')")
+    @PreAuthorize("hasAnyAuthority('guia:create') or hasAnyRole('ADMIN')")
     public ResponseEntity<GuiaDto> createGuia(@Valid @RequestBody GuiaCreateRequest request) {
         logger.info("Requisição para criar nova guia para paciente: {}", request.getPacienteId());
 
@@ -56,7 +55,7 @@ public class GuiaController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('guia:update')")
+    @PreAuthorize("hasAnyAuthority('guia:update') or hasAnyRole('ADMIN')")
     public ResponseEntity<GuiaDto> updateGuia(
             @PathVariable UUID id,
             @Valid @RequestBody GuiaUpdateRequest request) {
@@ -67,7 +66,7 @@ public class GuiaController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('guia:delete')")
+    @PreAuthorize("hasAnyAuthority('guia:delete') or hasAnyRole('ADMIN')")
     public ResponseEntity<Void> deleteGuia(@PathVariable UUID id) {
         logger.info("Requisição para deletar guia com ID: {}", id);
 

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
@@ -96,7 +96,7 @@ public class PacienteController {
         return ResponseUtil.success(pacientes);
     }
 
-    @GetMapping("/unidade/{unidade")
+    @GetMapping("/unidade/{unidade}")
     public ResponseEntity<Page<PacienteSummaryDto>> getPacientesByUnidade(
             @RequestParam Paciente.UnidadeEnum unidade,
             @PageableDefault(size = 20) Pageable pageable

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
@@ -119,7 +119,7 @@ public class PacienteController {
         return ResponseUtil.success(pacientes);
     }
 
-    @GetMapping("{id/guias")
+    @GetMapping("{id}/guias")
     public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByPacienteId(
             @PathVariable UUID id,
             @PageableDefault(size = 20) Pageable pageable

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
@@ -14,6 +14,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -24,14 +26,20 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/pacientes")
 @RequiredArgsConstructor
-@PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
 public class PacienteController {
 
     private static final Logger logger = LoggerFactory.getLogger(PacienteController.class);
     private final PacienteService pacienteService;
 
     @GetMapping
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Page<PacienteSummaryDto>> getAllPacientes(@PageableDefault(size = 20) Pageable pageable) {
+
+        // ✅ Debug temporário
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        logger.info("Usuário: {}", auth.getName());
+        logger.info("Autoridades: {}", auth.getAuthorities());
+
         logger.info("Requisição para listar todos os pacientes");
 
         Page<PacienteSummaryDto> pacientes = pacienteService.getAllPacientes(pageable);
@@ -39,6 +47,7 @@ public class PacienteController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<PacienteDto> getPacienteById(@PathVariable UUID id) {
         logger.info("Requisição para buscar paciente com ID: {}", id);
 
@@ -47,17 +56,16 @@ public class PacienteController {
     }
 
     @PostMapping
-    @PreAuthorize("hasAnyAuthority('paciente:create')")
+    @PreAuthorize("hasAnyAuthority('paciente:create') or hasRole('ADMIN')")
     public ResponseEntity<PacienteDto> createPaciente(@Valid @RequestBody PacienteCreateRequest request) {
         logger.info("Requisição para criar novo paciente: {}", request.getNome());
 
         PacienteDto createdPaciente = pacienteService.createPaciente(request);
         return ResponseUtil.success(createdPaciente);
-
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('paciente:update')")
+    @PreAuthorize("hasAnyAuthority('paciente:update') or hasRole('ADMIN')")
     public ResponseEntity<PacienteDto> updatePaciente(@PathVariable UUID id,
                                                       @Valid @RequestBody PacienteUpdateRequest request) {
         logger.info("Requisição para atualizar paciente com ID: {}", id);
@@ -67,7 +75,7 @@ public class PacienteController {
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('paciente:delete')")
+    @PreAuthorize("hasAnyAuthority('paciente:delete') or hasRole('ADMIN')")
     public ResponseEntity<Void> deletePaciente(@PathVariable UUID id) {
         logger.info("Requisição para deletar paciente com ID: {}", id);
 
@@ -76,6 +84,7 @@ public class PacienteController {
     }
 
     @GetMapping("/search")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Page<PacienteSummaryDto>> searchPacientseByNome(
             @RequestParam String nome,
             @PageableDefault(size = 20) Pageable pageable) {
@@ -86,10 +95,10 @@ public class PacienteController {
     }
 
     @GetMapping("/convenio/{convenioId}")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Page<PacienteSummaryDto>> getPacientesByConvenio(
             @PathVariable UUID convenioId,
-            @PageableDefault(size = 20) Pageable pageable
-    ) {
+            @PageableDefault(size = 20) Pageable pageable) {
         logger.info("Requisição para buscar pacientes do convênio: {}", convenioId);
 
         Page<PacienteSummaryDto> pacientes = pacienteService.getPacientesByConvenio(convenioId, pageable);
@@ -97,33 +106,33 @@ public class PacienteController {
     }
 
     @GetMapping("/unidade/{unidade}")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Page<PacienteSummaryDto>> getPacientesByUnidade(
-            @RequestParam Paciente.UnidadeEnum unidade,
-            @PageableDefault(size = 20) Pageable pageable
-    ) {
+            @PathVariable Paciente.UnidadeEnum unidade,
+            @PageableDefault(size = 20) Pageable pageable) {
         logger.info("Requisição para buscar pacientes pela unidade: {}", unidade);
 
         Page<PacienteSummaryDto> pacientes = pacienteService.getPacientesByUnidade(unidade, pageable);
         return ResponseUtil.success(pacientes);
     }
 
-
     @GetMapping("/data-nascimento")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Page<PacienteSummaryDto>> getPacientesByDataNascimento(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-            Pageable pageable) {
+            @PageableDefault(size = 20) Pageable pageable) {
         logger.info("Requisição para buscar pacientes por data de nascimento entre {} e {}", startDate, endDate);
 
         Page<PacienteSummaryDto> pacientes = pacienteService.getPacientesByDataNascimento(startDate, endDate, pageable);
         return ResponseUtil.success(pacientes);
     }
 
-    @GetMapping("{id}/guias")
+    @GetMapping("/{id}/guias")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByPacienteId(
             @PathVariable UUID id,
-            @PageableDefault(size = 20) Pageable pageable
-    ) {
+            @PageableDefault(size = 20) Pageable pageable) {
         logger.info("Requisição para buscar guias do paciente com ID: {}", id);
 
         Page<GuiaSummaryDto> guias = pacienteService.getGuiasByPacienteId(id, pageable);
@@ -131,6 +140,7 @@ public class PacienteController {
     }
 
     @GetMapping("/stats")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Map<String, Object>> getPacientesStats() {
         logger.info("Requisição para buscar estatísticas dos pacientes");
 
@@ -142,8 +152,10 @@ public class PacienteController {
         return ResponseUtil.success(stats);
     }
 
+    @GetMapping("/convenio/{convenioId}/count")
+    @PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
     public ResponseEntity<Map<String, Long>> countPacientesByConvenio(@PathVariable UUID convenioId) {
-        logger.info ("Requisição para contar pacientes do convênio com ID: {}", convenioId);
+        logger.info("Requisição para contar pacientes do convênio com ID: {}", convenioId);
 
         long count = pacienteService.countPacientesByConvenio(convenioId);
         Map<String, Long> response = new HashMap<>();
@@ -152,7 +164,3 @@ public class PacienteController {
         return ResponseUtil.success(response);
     }
 }
-
-
-
-

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
@@ -1,0 +1,158 @@
+package com.intranet.backend.controllers;
+
+import com.intranet.backend.dto.*;
+import com.intranet.backend.model.Paciente;
+import com.intranet.backend.service.PacienteService;
+import com.intranet.backend.util.ResponseUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/pacientes")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('paciente:read')")
+public class PacienteController {
+
+    private static final Logger logger = LoggerFactory.getLogger(PacienteController.class);
+    private final PacienteService pacienteService;
+
+    @GetMapping
+    public ResponseEntity<Page<PacienteSummaryDto>> getAllPacientes(@PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para listar todos os pacientes");
+
+        Page<PacienteSummaryDto> pacientes = pacienteService.getAllPacientes(pageable);
+        return ResponseUtil.success(pacientes);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PacienteDto> getPacienteById(@PathVariable UUID id) {
+        logger.info("Requisição para buscar paciente com ID: {}", id);
+
+        PacienteDto paciente = pacienteService.getPacienteById(id);
+        return ResponseUtil.success(paciente);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('paciente:create')")
+    public ResponseEntity<PacienteDto> createPaciente(@Valid @RequestBody PacienteCreateRequest request) {
+        logger.info("Requisição para criar novo paciente: {}", request.getNome());
+
+        PacienteDto createdPaciente = pacienteService.createPaciente(request);
+        return ResponseUtil.success(createdPaciente);
+
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('paciente:update')")
+    public ResponseEntity<PacienteDto> updatePaciente(@PathVariable UUID id,
+                                                      @Valid @RequestBody PacienteUpdateRequest request) {
+        logger.info("Requisição para atualizar paciente com ID: {}", id);
+
+        PacienteDto updatedPaciente = pacienteService.updatePaciente(id, request);
+        return ResponseUtil.success(updatedPaciente);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('paciente:delete')")
+    public ResponseEntity<Void> deletePaciente(@PathVariable UUID id) {
+        logger.info("Requisição para deletar paciente com ID: {}", id);
+
+        pacienteService.deletePaciente(id);
+        return ResponseUtil.noContent();
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<PacienteSummaryDto>> searchPacientseByNome(
+            @RequestParam String nome,
+            @PageableDefault(size = 20) Pageable pageable) {
+        logger.info("Requisição para buscar pacientes por nome: {}", nome);
+
+        Page<PacienteSummaryDto> pacientes = pacienteService.searchPacientesByNome(nome, pageable);
+        return ResponseUtil.success(pacientes);
+    }
+
+    @GetMapping("/convenio/{convenioId}")
+    public ResponseEntity<Page<PacienteSummaryDto>> getPacientesByConvenio(
+            @PathVariable UUID convenioId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        logger.info("Requisição para buscar pacientes do convênio: {}", convenioId);
+
+        Page<PacienteSummaryDto> pacientes = pacienteService.getPacientesByConvenio(convenioId, pageable);
+        return ResponseUtil.success(pacientes);
+    }
+
+    @GetMapping("/unidade/{unidade")
+    public ResponseEntity<Page<PacienteSummaryDto>> getPacientesByUnidade(
+            @RequestParam Paciente.UnidadeEnum unidade,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        logger.info("Requisição para buscar pacientes pela unidade: {}", unidade);
+
+        Page<PacienteSummaryDto> pacientes = pacienteService.getPacientesByUnidade(unidade, pageable);
+        return ResponseUtil.success(pacientes);
+    }
+
+
+    @GetMapping("/data-nascimento")
+    public ResponseEntity<Page<PacienteSummaryDto>> getPacientesByDataNascimento(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            Pageable pageable) {
+        logger.info("Requisição para buscar pacientes por data de nascimento entre {} e {}", startDate, endDate);
+
+        Page<PacienteSummaryDto> pacientes = pacienteService.getPacientesByDataNascimento(startDate, endDate, pageable);
+        return ResponseUtil.success(pacientes);
+    }
+
+    @GetMapping("{id/guias")
+    public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByPacienteId(
+            @PathVariable UUID id,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        logger.info("Requisição para buscar guias do paciente com ID: {}", id);
+
+        Page<GuiaSummaryDto> guias = pacienteService.getGuiasByPacienteId(id, pageable);
+        return ResponseUtil.success(guias);
+    }
+
+    @GetMapping("/stats")
+    public ResponseEntity<Map<String, Object>> getPacientesStats() {
+        logger.info("Requisição para buscar estatísticas dos pacientes");
+
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("totalPacientes", pacienteService.countTotalPacientes());
+        stats.put("pacientesKids", pacienteService.countPacientesByUnidade(Paciente.UnidadeEnum.KIDS));
+        stats.put("pacientesSenior", pacienteService.countPacientesByUnidade(Paciente.UnidadeEnum.SENIOR));
+
+        return ResponseUtil.success(stats);
+    }
+
+    public ResponseEntity<Map<String, Long>> countPacientesByConvenio(@PathVariable UUID convenioId) {
+        logger.info ("Requisição para contar pacientes do convênio com ID: {}", convenioId);
+
+        long count = pacienteService.countPacientesByConvenio(convenioId);
+        Map<String, Long> response = new HashMap<>();
+        response.put("count", count);
+
+        return ResponseUtil.success(response);
+    }
+}
+
+
+
+

--- a/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/PacienteController.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/pacientes")
 @RequiredArgsConstructor
-@PreAuthorize("hasAnyAuthority('paciente:read')")
+@PreAuthorize("hasAnyAuthority('paciente:read') or hasRole('ADMIN')")
 public class PacienteController {
 
     private static final Logger logger = LoggerFactory.getLogger(PacienteController.class);

--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaCreateRequest.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaCreateRequest.java
@@ -1,0 +1,38 @@
+package com.intranet.backend.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FichaCreateRequest {
+
+    @NotNull(message = "A guia é obrigatória")
+    private UUID guiaId;
+
+    @NotBlank(message = "A especialidade é obrigatória")
+    @Size(max = 100, message = "A especialidade deve ter no máximo 100 caracteres")
+    private String especialidade;
+
+    @NotNull(message = "A quantidade autorizada é obrigatória")
+    @Min(value = 1, message = "A quantidade autorizada deve ser maior que zero")
+    @Max(value = 999, message = "A quantidade autorizada não pode ser maior que 999")
+    private Integer quantidadeAutorizada;
+
+    @NotNull(message = "O convênio é obrigatório")
+    private UUID convenioId;
+
+    @NotNull(message = "O mês é obrigatório")
+    @Min(value = 1, message = "O mês deve ser pelo menos 1")
+    @Max(value = 12, message = "O mês não pode ser maior que 12")
+    private Integer mes;
+
+    @NotNull(message = "O ano é obrigatório")
+    @Min(value = 2020, message = "O ano deve ser pelo menos 2020")
+    private Integer ano;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaDto.java
@@ -1,0 +1,27 @@
+package com.intranet.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FichaDto {
+    private UUID id;
+    private UUID guiaId;
+    private String pacienteNome;
+    private String especialidade;
+    private Integer quantidadeAutorizada;
+    private UUID convenioId;
+    private String convenioNome;
+    private Integer mes;
+    private Integer ano;
+    private UUID usuarioResponsavelId;
+    private String usuarioResponsavelNome;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaSummaryDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaSummaryDto.java
@@ -1,0 +1,23 @@
+package com.intranet.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FichaSummaryDto {
+    private UUID id;
+    private String pacienteNome;
+    private String especialidade;
+    private Integer quantidadeAutorizada;
+    private String convenioNome;
+    private Integer mes;
+    private Integer ano;
+    private String usuarioResponsavelNome;
+    private LocalDateTime createdAt;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaUpdateRequest.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.intranet.backend.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FichaUpdateRequest {
+
+    @Size(max = 100, message = "A especialidade deve ter no máximo 100 caracteres")
+    private String especialidade;
+
+    @Min(value = 1, message = "A quantidade autorizada deve ser pelo menos 1")
+    @Max(value = 999, message = "A quantidade autorizada não pode ser maior que 999")
+    private Integer quantidadeAutorizada;
+
+    private UUID convenioId;
+
+    @Min(value = 1, message = "Mês deve estar entre 1 e 12")
+    @Max(value = 12, message = "Mês deve estar entre 1 e 12")
+    private Integer mes;
+
+    @Min(value = 2020, message = "Ano deve ser a partir de 2020")
+    private Integer ano;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/GuiaCreateRequest.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/GuiaCreateRequest.java
@@ -1,0 +1,55 @@
+package com.intranet.backend.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuiaCreateRequest {
+
+    @NotNull(message = "O paciente é obrigatório")
+    private UUID pacienteId;
+
+    @NotEmpty(message = "Pelo menos uma especialidade deve ser informada")
+    @Size(max = 10, message = "A quantidade máxima de especialidades é 10")
+    private List<@NotBlank(message = "Especialidade não pode ser vazia") String> especialidades;
+
+    @NotNull(message = "A quantidade autorizada é obrigatória")
+    @Min(value = 1, message = "A quantidade autorizada deve ser pelo menos 1")
+    @Max(value = 999, message = "A quantidade autorizada não pode ser maior que 999")
+    private Integer quantidadeAutorizada;
+
+    @NotNull(message = "O convenio é obrigatório")
+    private UUID convenioId;
+
+    @NotNull(message = "O mês é obrigatório")
+    @Min(value = 1, message = "O mês deve ser pelo menos 1")
+    @Max(value = 12, message = "O mês não pode ser maior que 12")
+    private Integer mes;
+
+    @NotNull(message = "O ano é obrigatório")
+    @Min(value = 2000, message = "O ano deve ser pelo menos 2020")
+    private Integer ano;
+
+    @NotNull(message = "A data de validade é obrigatória")
+    @Future(message = "A data de validade deve ser futura")
+    private LocalDate validade;
+
+    @Size(max = 100, message = "O lote deve ter no máximo 100 caracteres")
+    private String lote;
+
+    @Min(value = 0, message = "O valor deve ser pelo menos 0")
+    private Integer quantidadeFaturada;
+
+    @DecimalMin(value = "0.0", message = "O valor não pode ser negativo")
+    @DecimalMax(value = "999999.99", message = "O valor não pode exceder 999.999,99")
+    private BigDecimal valorReais = BigDecimal.ZERO;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/GuiaDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/GuiaDto.java
@@ -1,0 +1,38 @@
+package com.intranet.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuiaDto {
+    private UUID id;
+    private UUID pacienteId;
+    private String pacienteNome;
+    private List<String> especialidades;
+    private Integer quantidadeAutorizada;
+    private UUID convenioId;
+    private String convenioNome;
+    private Integer mes;
+    private Integer ano;
+    private LocalDate validade;
+    private String lote;
+    private Integer quantidadeFaturada;
+    private BigDecimal valorReais;
+    private UUID usuarioResponsavelId;
+    private String usuarioResponsavelNome;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private long TotalFichas;
+    private boolean isVencida;
+    private boolean isQuantidadeExcedida;
+    private Integer quantidadeRestante;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/GuiaSummaryDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/GuiaSummaryDto.java
@@ -1,0 +1,30 @@
+package com.intranet.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuiaSummaryDto {
+    private UUID id;
+    private String pacienteNome;
+    private List<String> especialidades;
+    private Integer quantidadeAutorizada;
+    private String convenioNome;
+    private Integer mes;
+    private Integer ano;
+    private LocalDate validade;
+    private Integer quatidadeFaturada;
+    private BigDecimal valorReais;
+    private String usuarioResponsavelNome;
+    private long TotalFichas;
+    private boolean isVencida;
+    private boolean isQuantidadeExcedida;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/GuiaUpdateRequest.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/GuiaUpdateRequest.java
@@ -1,0 +1,47 @@
+package com.intranet.backend.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuiaUpdateRequest {
+
+    @Size(min = 1, max = 10, message = "Máximo de 10 especialidades")
+    private List<@NotBlank(message = "Especialidade não pode ser vazia") String> especialidades;
+
+    @Min(value = 1, message = "A quantidade autorizada deve ser maior que zero")
+    @Max(value = 999, message = "A quantidade autorizada não pode ser maior que 999")
+    private Integer quantidadeAutorizada;
+
+    private UUID convenioId;
+
+    @Min(value = 1, message = "O mês deve ser pelo menos 1")
+    @Max(value = 12, message = "O mês não pode ser maior que 12")
+    private Integer mes;
+
+    @Min(value = 2020, message = "O ano deve ser pelo menos 2020")
+    private Integer ano;
+
+    private LocalDate validade;
+
+    @Size(max = 100, message = "O lote deve ter no máximo 100 caracteres")
+    private String lote;
+
+    @Min(value = 0, message = "A quantidade faturada não pode ser negativa")
+    private Integer quantidadeFaturada;
+
+    @DecimalMin(value = "0.0", message = "O valor não pode ser negativo")
+    @DecimalMax(value = "999999.99", message = "O valor não pode exceder 999.999,99")
+    private BigDecimal valorReais;
+
+
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/PacienteCreateRequest.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/PacienteCreateRequest.java
@@ -1,0 +1,34 @@
+package com.intranet.backend.dto;
+
+import com.intranet.backend.model.Paciente;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PacienteCreateRequest {
+
+    @NotBlank(message = "O nome é obrigatório")
+    @Size(min = 2, max = 255, message = "O nome deve ter entre 2 e 255 caracteres")
+    private String nome;
+
+    @NotNull(message = "A data de nascimento é obrigatória")
+    private LocalDate dataNascimento;
+
+    @Size(max = 255, message = "O nome do responsável ter no máximo 255 caracteres")
+    private String responsavel;
+
+    @NotNull(message = "O convênio é obrigatório")
+    private UUID convenioId;
+
+    @NotNull(message = "A unidade é obrigatória")
+    private Paciente.UnidadeEnum unidade;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/PacienteDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/PacienteDto.java
@@ -1,0 +1,28 @@
+package com.intranet.backend.dto;
+
+import com.intranet.backend.model.Paciente;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PacienteDto {
+    private UUID id;
+    private String nome;
+    private LocalDate dataNascimento;
+    private String responsavel;
+    private UUID convenioId;
+    private String convenioNome;
+    private Paciente.UnidadeEnum unidade;
+    private UUID createdById;
+    private String createdByName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private long TotalGuias;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/PacienteSummaryDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/PacienteSummaryDto.java
@@ -1,0 +1,22 @@
+package com.intranet.backend.dto;
+
+import com.intranet.backend.model.Paciente;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PacienteSummaryDto {
+    private UUID id;
+    private String nome;
+    private LocalDate dataNascimento;
+    private String convenioNome;
+    private Paciente.UnidadeEnum unidade;
+    private long totalGuias;
+    private boolean hasGuiasVencidas;
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/PacienteUpdateRequest.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/PacienteUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.intranet.backend.dto;
+
+import com.intranet.backend.model.Paciente;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PacienteUpdateRequest {
+
+    @Size(min = 2, max = 255, message = "O nome deve ter entre 2 e 255 caracteres")
+    private String nome;
+
+    private LocalDate dataNascimento;
+
+    @Size(max = 255, message = "O nome do responsável ter no máximo 255 caracteres")
+    private String responsavel;
+
+    private UUID convenioId;
+
+    private Paciente.UnidadeEnum unidade;
+
+}

--- a/apps/backend/src/main/java/com/intranet/backend/model/Ficha.java
+++ b/apps/backend/src/main/java/com/intranet/backend/model/Ficha.java
@@ -1,0 +1,80 @@
+package com.intranet.backend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "fichas", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"guia_id", "especialidade"})
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Ficha {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guia_id", nullable = false)
+    private Guia guia;
+
+    @Column(name = "especialidade", nullable = false, length = 100)
+    private String especialidade;
+
+    @Column(name = "quantidade_autorizada", nullable = false)
+    private Integer quantidadeAutorizada;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "convenio_id", nullable = false)
+    private Convenio convenio;
+    
+    @Column(name = "mes", nullable = false)
+    private Integer mes;
+
+    @Column(name = "ano", nullable = false)
+    private Integer ano;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_responsavel", nullable = false)
+    private User usuarioResponsavel;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Ficha ficha = (Ficha) o;
+        return id != null && id.equals(ficha.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    public String getPacienteNome() {
+        return guia != null && guia.getPaciente() != null ? guia.getPaciente().getNome() : null;
+    }
+
+    public String getConvenioNome() {
+        return convenio != null ? convenio.getName() : null;
+    }
+}

--- a/apps/backend/src/main/java/com/intranet/backend/model/Guia.java
+++ b/apps/backend/src/main/java/com/intranet/backend/model/Guia.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -31,9 +33,9 @@ public class Guia {
     @JoinColumn(name = "paciente_id", nullable = false)
     private Paciente paciente;
 
-    @ElementCollection
-    @CollectionTable(name = "guia_especialidades", joinColumns = @JoinColumn(name = "guia_id"))
-    @Column(name = "especialidade")
+
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "especialidades", columnDefinition = "text[]")
     private List<String> especialidades = new ArrayList<>();
 
     @Column(name = "quantidade_autorizada", nullable = false)

--- a/apps/backend/src/main/java/com/intranet/backend/model/Guia.java
+++ b/apps/backend/src/main/java/com/intranet/backend/model/Guia.java
@@ -1,0 +1,103 @@
+package com.intranet.backend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "guias")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Guia {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    @ElementCollection
+    @CollectionTable(name = "guia_especialidades", joinColumns = @JoinColumn(name = "guia_id"))
+    @Column(name = "especialidade")
+    private List<String> especialidades = new ArrayList<>();
+
+    @Column(name = "quantidade_autorizada", nullable = false)
+    private Integer quantidadeAutorizada;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "convenio_id", nullable = false)
+    private Convenio convenio;
+
+    @Column(name = "mes", nullable = false)
+    private Integer mes;
+
+    @Column(name = "ano", nullable = false)
+    private Integer ano;
+
+    @Column(name = "validade", nullable = false)
+    private LocalDate validade;
+
+    @Column(name = "lote", length = 100)
+    private String lote;
+
+    @Column(name = "quantidade_faturada", nullable = false)
+    private Integer quantidadeFaturada = 0;
+
+    @Column(name = "valor_reais", nullable = false, precision = 10, scale = 2)
+    private BigDecimal valorReais = BigDecimal.ZERO;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_responsavel", nullable = false)
+    private User usuarioResponsavel;
+
+    @OneToMany(mappedBy = "guia", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Ficha> fichas  = new ArrayList<>();
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Guia guia = (Guia) o;
+      return id != null && id.equals(guia.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    public boolean isVencida() {
+        return validade != null && validade.isBefore(LocalDate.now());
+    }
+
+    public boolean isQuantidadeExcedida() {
+        return quantidadeFaturada > quantidadeAutorizada;
+    }
+
+    public Integer getQuantidadeRestante() {
+        return quantidadeAutorizada - quantidadeFaturada;
+    }
+}

--- a/apps/backend/src/main/java/com/intranet/backend/model/Paciente.java
+++ b/apps/backend/src/main/java/com/intranet/backend/model/Paciente.java
@@ -1,0 +1,88 @@
+package com.intranet.backend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "pacientes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Paciente {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(name = "nome", nullable = false, length = 255)
+    private String nome;
+
+    @Column(name = "data_nascimento", nullable = false)
+    private LocalDate dataNascimento;
+
+    @Column(name="responsavel", length = 255)
+    private String responsavel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "convenio_id", nullable = false)
+    private Convenio convenio;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "unidade", nullable = false)
+    private UnidadeEnum unidade;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @OneToMany(mappedBy = "paciente", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Guia> guias = new ArrayList<>();
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public enum UnidadeEnum {
+        KIDS("Kids"),
+        SENIOR("Senior");
+
+        private final String displayName;
+
+        UnidadeEnum(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Paciente paciente = (Paciente) o;
+        return id != null && id.equals(paciente.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/apps/backend/src/main/java/com/intranet/backend/repository/FichaRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/FichaRepository.java
@@ -1,0 +1,45 @@
+package com.intranet.backend.repository;
+
+import com.intranet.backend.model.Ficha;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface FichaRepository extends JpaRepository<Ficha, UUID> {
+
+    @Query("SELECT f FROM Ficha f WHERE f.guia.id = :guiaId ORDER BY f.especialidade ASC")
+    List<Ficha> findByGuiaId(@Param("guiaId") UUID guiaId);
+
+    @Query("SELECT f FROM Ficha f WHERE f.guia.paciente.id = :pacienteId ORDER BY f.createdAt DESC")
+    Page<Ficha> findByPacienteId(@Param("pacienteId") UUID pacienteId, Pageable pageable);
+
+    @Query("SELECT f FROM Ficha f WHERE f.convenio.id = :convenioId ORDER BY f.createdAt DESC")
+    Page<Ficha> findByConvenioId(@Param("convenioId") UUID convenioId, Pageable pageable);
+
+    @Query("SELECT f FROM Ficha f WHERE f.especialidade ILIKE %:especialidade%")
+    Page<Ficha> findByEspecialidadeContainingIgnoreCase(@Param("especialidade") String especialidade, Pageable pageable);
+
+    @Query("SELECT f FROM Ficha f WHERE f.mes = :mes AND f.ano = :ano ORDER BY f.createdAt DESC")
+    Page<Ficha> findByMesAndAno(@Param("mes") Integer mes, @Param("ano") Integer ano, Pageable pageable);
+
+    @Query("SELECT f FROM Ficha f WHERE f.usuarioResponsavel.id = :userId ORDER BY f.createdAt DESC")
+    Page<Ficha> findByUsuarioResponsavelId(@Param("userId") UUID userId, Pageable pageable);
+
+    @Query("SELECT f FROM Ficha f LEFT JOIN FETCH f.guia g LEFT JOIN FETCH g.paciente " +
+            "LEFT JOIN FETCH f.convenio LEFT JOIN FETCH f.usuarioResponsavel WHERE f.id = :id")
+    Optional<Ficha> findByIdWithRelations(@Param("id") UUID id);
+
+    boolean existsByGuiaIdAndEspecialidade(@Param("guiaId") UUID guiaId, @Param("especialidade") String especialidade);
+
+    @Query("SELECT f FROM Ficha f LEFT JOIN FETCH f.guia g LEFT JOIN FETCH g.paciente " +
+            "LEFT JOIN FETCH f.convenio LEFT JOIN FETCH f.usuarioResponsavel")
+    Page<Ficha> findAllWithRelations(Pageable pageable);
+}

--- a/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -46,6 +45,9 @@ public interface GuiaRepository extends JpaRepository<Guia, UUID> {
             "LEFT JOIN FETCH g.usuarioResponsavel WHERE g.id = :id")
     Optional<Guia> findByIdWithRelations(@Param("id") UUID id);
 
-    @Query("SELECT g FROM Guia g WHERE :especialidade = ANY(g.especialidades)")
+    // ✅ CORRIGIDO: Query nativa para buscar em array PostgreSQL
+    @Query(value = "SELECT * FROM guias g WHERE :especialidade = ANY(g.especialidades) ORDER BY g.created_at DESC",
+            countQuery = "SELECT COUNT(*) FROM guias g WHERE :especialidade = ANY(g.especialidades)",
+            nativeQuery = true)
     Page<Guia> findByEspecialidadesContaining(@Param("especialidade") String especialidade, Pageable pageable);
 }

--- a/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
@@ -1,0 +1,51 @@
+package com.intranet.backend.repository;
+
+import com.intranet.backend.model.Guia;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface GuiaRepository extends JpaRepository<Guia, UUID> {
+
+    @Query("SELECT g FROM Guia g WHERE g.paciente.id = :pacienteId ORDER BY g.createdAt DESC")
+    Page<Guia> findByPacienteId(@Param("pacienteId") UUID pacienteId, Pageable pageable);
+
+    @Query("SELECT g FROM Guia g WHERE g.convenio.id = :convenioId ORDER BY g.createdAt DESC")
+    Page<Guia> findByConvenioId(@Param("convenioId") UUID convenioId, Pageable pageable);
+
+    @Query("SELECT g FROM Guia g WHERE g.mes = :mes AND g.ano = :ano ORDER BY g.createdAt DESC")
+    Page<Guia> findByMesAndAno(@Param("mes") Integer mes, @Param("ano") Integer ano, Pageable pageable);
+
+    @Query("SELECT g FROM Guia g WHERE g.validade < CURRENT_DATE ORDER BY g.validade ASC")
+    Page<Guia> findGuiasVencidas(Pageable pageable);
+
+    @Query("SELECT g FROM Guia g WHERE g.quantidadeFaturada > g.quantidadeAutorizada")
+    Page<Guia> findGuiasComQuantidadeExcedida(Pageable pageable);
+
+    @Query("SELECT g FROM Guia g WHERE g.validade BETWEEN :startDate AND :endDate")
+    Page<Guia> findByValidadeBetween(@Param("startDate") LocalDate startDate,
+                                     @Param("endDate") LocalDate endDate,
+                                     Pageable pageable);
+
+    @Query("SELECT g FROM Guia g WHERE g.usuarioResponsavel.id = :userId ORDER BY g.createdAt DESC")
+    Page<Guia> findByUsuarioResponsavelId(@Param("userId") UUID userId, Pageable pageable);
+
+    @Query("SELECT COUNT(f) FROM Ficha f WHERE f.guia.id = :guiaId")
+    long countFichasByGuiaId(@Param("guiaId") UUID guiaId);
+
+    @Query("SELECT g FROM Guia g LEFT JOIN FETCH g.paciente LEFT JOIN FETCH g.convenio " +
+            "LEFT JOIN FETCH g.usuarioResponsavel WHERE g.id = :id")
+    Optional<Guia> findByIdWithRelations(@Param("id") UUID id);
+
+    @Query("SELECT g FROM Guia g WHERE :especialidade = ANY(g.especialidades)")
+    Page<Guia> findByEspecialidadesContaining(@Param("especialidade") String especialidade, Pageable pageable);
+}

--- a/apps/backend/src/main/java/com/intranet/backend/repository/PacienteRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/PacienteRepository.java
@@ -1,0 +1,54 @@
+package com.intranet.backend.repository;
+
+import com.intranet.backend.model.Paciente;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PacienteRepository extends JpaRepository<Paciente, Integer> {
+
+    @Query("SELECT p FROM Paciente p WHERE p.id = :id")
+    Optional<Paciente> findById(UUID id);
+
+    @Query("SELECT p FROM Paciente p WHERE p.id = :id")
+    boolean existsById(UUID id);
+
+    @Query("DELETE FROM Paciente p WHERE p.id = :id")
+    void deleteById(UUID id);
+
+    @Query("SELECT p FROM Paciente p WHERE p.nome ILIKE %:nome%")
+    Page<Paciente> findByNomeContainingIgnoreCase(@Param("nome") String nome, Pageable pageable);
+
+    @Query("SELECT p FROM Paciente p WHERE p.convenio.id = :convenioId")
+    Page<Paciente> findByConvenioId(@Param("convenioId") UUID convenioId, Pageable pageable);
+
+    @Query("SELECT p FROM Paciente p WHERE p.unidade = :unidade")
+    Page<Paciente> findByUnidade(@Param("unidade") Paciente.UnidadeEnum unidade, Pageable pageable);
+
+    @Query("SELECT p FROM Paciente p WHERE p.dataNascimento BETWEEN :startDate AND :endDate")
+    Page<Paciente> findByDataNascimentoBetween(@Param("startDate") LocalDate startDate,
+                                               @Param("endDate") LocalDate endDate,
+                                               Pageable pageable);
+
+    @Query("SELECT COUNT(g) FROM Guia g WHERE g.paciente.id = :pacienteId")
+    long countGuiasByPacienteId(@Param("pacienteId") UUID pacienteId);
+
+    @Query("SELECT CASE WHEN COUNT(g) > 0 THEN true ELSE false END FROM Guia g " +
+            "WHERE g.paciente.id = :pacienteId AND g.validade < CURRENT_DATE")
+    boolean hasGuiasVencidas(@Param("pacienteId") UUID pacienteId);
+
+    @Query("SELECT p FROM Paciente p LEFT JOIN FETCH p.convenio WHERE p.id = :id")
+    Optional<Paciente> findByIdWithConvenio(@Param("id") UUID id);
+
+    @Query("SELECT p FROM Paciente p LEFT JOIN FETCH p.convenio LEFT JOIN FETCH p.createdBy")
+    Page<Paciente> findAllWithRelations(Pageable pageable);
+}

--- a/apps/backend/src/main/java/com/intranet/backend/repository/PacienteRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/PacienteRepository.java
@@ -9,21 +9,11 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface PacienteRepository extends JpaRepository<Paciente, Integer> {
-
-    @Query("SELECT p FROM Paciente p WHERE p.id = :id")
-    Optional<Paciente> findById(UUID id);
-
-    @Query("SELECT p FROM Paciente p WHERE p.id = :id")
-    boolean existsById(UUID id);
-
-    @Query("DELETE FROM Paciente p WHERE p.id = :id")
-    void deleteById(UUID id);
+public interface PacienteRepository extends JpaRepository<Paciente, UUID> {
 
     @Query("SELECT p FROM Paciente p WHERE p.nome ILIKE %:nome%")
     Page<Paciente> findByNomeContainingIgnoreCase(@Param("nome") String nome, Pageable pageable);

--- a/apps/backend/src/main/java/com/intranet/backend/service/FichaService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/FichaService.java
@@ -1,0 +1,39 @@
+package com.intranet.backend.service;
+
+import com.intranet.backend.dto.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FichaService {
+
+    Page<FichaSummaryDto> getAllFichas(Pageable pageable);
+
+    FichaDto getFichaById(UUID id);
+
+    FichaDto createFicha(FichaCreateRequest request);
+
+    FichaDto updateFicha(UUID id, FichaUpdateRequest request);
+
+    void deleteFicha(UUID id);
+
+    List<FichaDto> getFichasByGuiaId(UUID guiaId);
+
+    Page<FichaSummaryDto> getFichasByPacienteId(UUID pacienteId, Pageable pageable);
+
+    Page<FichaSummaryDto> getFichasByConvenioId(UUID convenioId, Pageable pageable);
+
+    Page<FichaSummaryDto> searchFichasByEspecialidade(String especialidade, Pageable pageable);
+
+    Page<FichaSummaryDto> getFichasByMesEAno(Integer mes, Integer ano, Pageable pageable);
+
+    Page<FichaSummaryDto> getFichasByUsuarioResponsavel(UUID userId, Pageable pageable);
+
+    long countTotalFichas();
+
+    long countFichasByGuia(UUID guiaId);
+
+    long countFichasByConvenio(UUID convenioId);
+}

--- a/apps/backend/src/main/java/com/intranet/backend/service/GuiaService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/GuiaService.java
@@ -1,0 +1,45 @@
+package com.intranet.backend.service;
+
+import com.intranet.backend.dto.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public interface GuiaService {
+
+    Page<GuiaSummaryDto> getAllGuias(Pageable pageable);
+
+    GuiaDto getGuiaById(UUID id);
+
+    GuiaDto createGuia(GuiaCreateRequest request);
+
+    GuiaDto updateGuia(UUID id, GuiaUpdateRequest request);
+
+    void deleteGuia(UUID id);
+
+    Page<GuiaSummaryDto> getGuiasByPaciente(UUID pacienteId, Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasByConvenio(UUID convenioId, Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasByMesEAno(Integer mes, Integer ano, Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasVencidas(Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasComQuantidadeExcedida(Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasByValidade(LocalDate startDate, LocalDate endDate, Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasByUsuarioResponsavel(UUID userId, Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasByEspecialidade(String especialidade, Pageable pageable);
+
+    Page<FichaSummaryDto> getFichasByGuiaId(UUID guiaId, Pageable pageable);
+
+    long countTotalGuias();
+
+    long countGuiasVencidas();
+
+    long countGuiasComQuantidadeExcedida();
+}

--- a/apps/backend/src/main/java/com/intranet/backend/service/PacienteService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/PacienteService.java
@@ -1,0 +1,37 @@
+package com.intranet.backend.service;
+
+import com.intranet.backend.dto.*;
+import com.intranet.backend.model.Paciente;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public interface PacienteService {
+    Page<PacienteSummaryDto> getAllPacientes(Pageable pageable);
+
+    PacienteDto getPacienteById(UUID id);
+
+    PacienteDto createPaciente(PacienteCreateRequest request);
+
+    PacienteDto updatePaciente(UUID id, PacienteUpdateRequest request);
+
+    void deletePaciente(UUID id);
+
+    Page<PacienteSummaryDto> searchPacientesByNome(String nome, Pageable pageable);
+
+    Page<PacienteSummaryDto> getPacientesByConvenio(UUID convenioId, Pageable pageable);
+
+    Page<PacienteSummaryDto> getPacientesByUnidade(Paciente.UnidadeEnum unidade, Pageable pageable);
+
+    Page<PacienteSummaryDto> getPacientesByDataNascimento(LocalDate startDate, LocalDate endDate, Pageable pageable);
+
+    Page<GuiaSummaryDto> getGuiasByPacienteId(UUID pacienteId, Pageable pageable);
+
+    long countTotalPacientes();
+
+    long countPacientesByConvenio(UUID convenioId);
+
+    long countPacientesByUnidade(Paciente.UnidadeEnum unidade);
+}

--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/GuiaServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/GuiaServiceImpl.java
@@ -1,0 +1,312 @@
+package com.intranet.backend.service.impl;
+
+import com.intranet.backend.dto.*;
+import com.intranet.backend.exception.ResourceNotFoundException;
+import com.intranet.backend.model.*;
+import com.intranet.backend.repository.*;
+import com.intranet.backend.service.GuiaService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GuiaServiceImpl implements GuiaService {
+
+    private static final Logger logger = LoggerFactory.getLogger(GuiaServiceImpl.class);
+
+    private final GuiaRepository guiaRepository;
+    private final PacienteRepository pacienteRepository;
+    private final ConvenioRepository convenioRepository;
+    private final UserRepository userRepository;
+    private final FichaRepository fichaRepository;
+
+    @Override
+    public Page<GuiaSummaryDto> getAllGuias(Pageable pageable) {
+        logger.info("Buscando todas as guias - página: {}, tamanho: {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<Guia> guias = guiaRepository.findAll(pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public GuiaDto getGuiaById(UUID id) {
+        logger.info("Buscando guia com ID: {}", id);
+
+        Guia guia = guiaRepository.findByIdWithRelations(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Guia com ID: " + id));
+
+        return mapToGuiaDto(guia);
+    }
+
+    @Override
+    @Transactional
+    public GuiaDto createGuia(GuiaCreateRequest request) {
+        logger.info("Criando nova guia para paciente ID: {}", request.getPacienteId());
+
+        Paciente paciente = pacienteRepository.findById(request.getPacienteId())
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente com ID: " + request.getPacienteId()));
+
+        Convenio convenio = convenioRepository.findById(request.getConvenioId())
+                .orElseThrow(() -> new ResourceNotFoundException("Convênio com ID: " + request.getConvenioId()));
+
+        Guia guia = new Guia();
+        guia.setPaciente(paciente);
+        guia.setConvenio(convenio);
+        guia.setEspecialidades(request.getEspecialidades());
+        guia.setQuantidadeAutorizada(request.getQuantidadeAutorizada());
+        guia.setMes(request.getMes());
+        guia.setAno(request.getAno());
+        guia.setValidade(request.getValidade());
+        guia.setLote(request.getLote());
+        guia.setQuantidadeFaturada(request.getQuantidadeFaturada());
+        guia.setValorReais(request.getValorReais());
+        guia.setUsuarioResponsavel(getCurrentUser());
+
+        Guia savedGuia = guiaRepository.save(guia);
+        logger.info("Guia criada com sucesso. ID: {}", savedGuia.getId());
+
+        return mapToGuiaDto(savedGuia);
+    }
+
+    @Override
+    @Transactional
+    public GuiaDto updateGuia(UUID id, GuiaUpdateRequest request) {
+        logger.info("Atualizando guia com ID: {}", id);
+
+        Guia guia = guiaRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Guia não encontrada com ID: " + id));
+
+        // Atualizar campos se fornecidos
+        if (request.getEspecialidades() != null) {
+            guia.setEspecialidades(request.getEspecialidades());
+        }
+
+        if (request.getQuantidadeAutorizada() != null) {
+            guia.setQuantidadeAutorizada(request.getQuantidadeAutorizada());
+        }
+
+        if (request.getConvenioId() != null) {
+            Convenio convenio = convenioRepository.findById(request.getConvenioId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Convênio não encontrado com ID: " + request.getConvenioId()));
+            guia.setConvenio(convenio);
+        }
+
+        if (request.getMes() != null) {
+            guia.setMes(request.getMes());
+        }
+
+        if (request.getAno() != null) {
+            guia.setAno(request.getAno());
+        }
+
+        if (request.getValidade() != null) {
+            guia.setValidade(request.getValidade());
+        }
+
+        if (request.getLote() != null) {
+            guia.setLote(request.getLote());
+        }
+
+        if (request.getQuantidadeFaturada() != null) {
+            guia.setQuantidadeFaturada(request.getQuantidadeFaturada());
+        }
+
+        if (request.getValorReais() != null) {
+            guia.setValorReais(request.getValorReais());
+        }
+
+        Guia updatedGuia = guiaRepository.save(guia);
+        logger.info("Guia atualizada com sucesso. ID: {}", updatedGuia.getId());
+
+        return mapToGuiaDto(updatedGuia);
+    }
+
+    @Override
+    @Transactional
+    public void deleteGuia(UUID id) {
+        logger.info("Excluindo guia com ID: {}", id);
+
+        if (!guiaRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Guia não encontrada com ID: " + id);
+        }
+
+        // Verificar se há fichas associadas
+        long totalFichas = guiaRepository.countFichasByGuiaId(id);
+        if (totalFichas > 0) {
+            throw new IllegalStateException("Não é possível excluir guia que possui fichas associadas");
+        }
+
+        guiaRepository.deleteById(id);
+        logger.info("Guia excluída com sucesso. ID: {}", id);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasByPaciente(UUID pacienteId, Pageable pageable) {
+        logger.info("Buscando guias do paciente: {}", pacienteId);
+
+        Page<Guia> guias = guiaRepository.findByPacienteId(pacienteId, pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasByConvenio(UUID convenioId, Pageable pageable) {
+        logger.info("Buscando guias do convênio: {}", convenioId);
+
+        Page<Guia> guias = guiaRepository.findByConvenioId(convenioId, pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasByMesEAno(Integer mes, Integer ano, Pageable pageable) {
+        logger.info("Buscando guias do mês {} de {}", mes, ano);
+
+        Page<Guia> guias = guiaRepository.findByMesAndAno(mes, ano, pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasVencidas(Pageable pageable) {
+        logger.info("Buscando guias vencidas");
+
+        Page<Guia> guias = guiaRepository.findGuiasVencidas(pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasComQuantidadeExcedida(Pageable pageable) {
+        logger.info("Buscando guias com quantidade excedida");
+
+        Page<Guia> guias = guiaRepository.findGuiasComQuantidadeExcedida(pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasByValidade(LocalDate startDate, LocalDate endDate, Pageable pageable) {
+        logger.info("Buscando guias com validade entre {} e {}", startDate, endDate);
+
+        Page<Guia> guias = guiaRepository.findByValidadeBetween(startDate, endDate, pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasByUsuarioResponsavel(UUID userId, Pageable pageable) {
+        logger.info("Buscando guias do usuário responsável: {}", userId);
+
+        Page<Guia> guias = guiaRepository.findByUsuarioResponsavelId(userId, pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasByEspecialidade(String especialidade, Pageable pageable) {
+        logger.info("Buscando guias da especialidade: {}", especialidade);
+
+        Page<Guia> guias = guiaRepository.findByEspecialidadesContaining(especialidade, pageable);
+        return guias.map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public Page<FichaSummaryDto> getFichasByGuiaId(UUID guiaId, Pageable pageable) {
+        logger.info("Buscando fichas da guia: {}", guiaId);
+
+        if (!guiaRepository.existsById(guiaId)) {
+            throw new ResourceNotFoundException("Guia não encontrada com ID: " + guiaId);
+        }
+
+        return fichaRepository.findAllWithRelations(pageable)
+                .map(this::mapToFichaSummaryDto);
+    }
+
+    @Override
+    public long countTotalGuias() {
+        return guiaRepository.count();
+    }
+
+    @Override
+    public long countGuiasVencidas() {
+        return guiaRepository.findGuiasVencidas(Pageable.unpaged()).getTotalElements();
+    }
+
+    @Override
+    public long countGuiasComQuantidadeExcedida() {
+        return guiaRepository.findGuiasComQuantidadeExcedida(Pageable.unpaged()).getTotalElements();
+    }
+
+    private User getCurrentUser() {
+        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new RuntimeException("Não foi possível encontrar o usuário atual"));
+    }
+
+    private GuiaDto mapToGuiaDto(Guia guia) {
+        long totalFichas = guiaRepository.countFichasByGuiaId(guia.getId());
+
+        return new GuiaDto(
+                guia.getId(),
+                guia.getPaciente().getId(),
+                guia.getPaciente().getNome(),
+                guia.getEspecialidades(),
+                guia.getQuantidadeAutorizada(),
+                guia.getConvenio().getId(),
+                guia.getConvenio().getName(),
+                guia.getMes(),
+                guia.getAno(),
+                guia.getValidade(),
+                guia.getLote(),
+                guia.getQuantidadeFaturada(),
+                guia.getValorReais(),
+                guia.getUsuarioResponsavel().getId(),
+                guia.getUsuarioResponsavel().getFullName(),
+                guia.getCreatedAt(),
+                guia.getUpdatedAt(),
+                totalFichas,
+                guia.isVencida(),
+                guia.isQuantidadeExcedida(),
+                guia.getQuantidadeRestante()
+        );
+    }
+
+    private GuiaSummaryDto mapToGuiaSummaryDto(Guia guia) {
+        long totalFichas = guiaRepository.countFichasByGuiaId(guia.getId());
+
+        return new GuiaSummaryDto(
+                guia.getId(),
+                guia.getPaciente().getNome(),
+                guia.getEspecialidades(),
+                guia.getQuantidadeAutorizada(),
+                guia.getConvenio().getName(),
+                guia.getMes(),
+                guia.getAno(),
+                guia.getValidade(),
+                guia.getQuantidadeFaturada(),
+                guia.getValorReais(),
+                guia.getUsuarioResponsavel().getFullName(),
+                totalFichas,
+                guia.isVencida(),
+                guia.isQuantidadeExcedida()
+        );
+    }
+
+    private FichaSummaryDto mapToFichaSummaryDto(Ficha ficha) {
+        return new FichaSummaryDto(
+                ficha.getId(),
+                ficha.getPacienteNome(),
+                ficha.getEspecialidade(),
+                ficha.getQuantidadeAutorizada(),
+                ficha.getConvenioNome(),
+                ficha.getMes(),
+                ficha.getAno(),
+                ficha.getUsuarioResponsavel().getFullName(),
+                ficha.getCreatedAt()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/PacienteServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/PacienteServiceImpl.java
@@ -1,0 +1,254 @@
+package com.intranet.backend.service.impl;
+
+import com.intranet.backend.dto.*;
+import com.intranet.backend.exception.ResourceNotFoundException;
+import com.intranet.backend.model.Convenio;
+import com.intranet.backend.model.Guia;
+import com.intranet.backend.model.Paciente;
+import com.intranet.backend.model.User;
+import com.intranet.backend.repository.ConvenioRepository;
+import com.intranet.backend.repository.GuiaRepository;
+import com.intranet.backend.repository.PacienteRepository;
+import com.intranet.backend.repository.UserRepository;
+import com.intranet.backend.service.PacienteService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PacienteServiceImpl implements PacienteService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PacienteServiceImpl.class);
+
+    private final PacienteRepository pacienteRepository;
+    private final ConvenioRepository convenioRepository;
+    private final UserRepository userRepository;
+    private final GuiaRepository guiaRepository;
+
+    @Override
+    public Page<PacienteSummaryDto> getAllPacientes(Pageable pageable) {
+        logger.info("Buscando todos os pacientes - página: {}, tamanho: {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<Paciente> pacientes = pacienteRepository.findAllWithRelations(pageable);
+        return pacientes.map(this::mapToPacienteSummaryDto);
+    }
+
+    @Override
+    public PacienteDto getPacienteById(UUID id) {
+        logger.info("Buscando paciente com ID: {}", id);
+
+        Paciente paciente = pacienteRepository.findByIdWithConvenio(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não econtrado com ID: " + id));
+
+        return mapToPacienteDto(paciente);
+    }
+
+    @Override
+    @Transactional
+    public PacienteDto createPaciente(PacienteCreateRequest request) {
+        logger.info("Criando novo paciente: {}", request.getNome());
+
+        Convenio convenio = convenioRepository.findById(request.getConvenioId())
+                .orElseThrow(() -> new ResourceNotFoundException("Convênio não encontrado com ID: " + request.getConvenioId()));
+
+        User currentUser = getCurrentUser();
+
+        Paciente paciente = new Paciente();
+        paciente.setNome(request.getNome());
+        paciente.setDataNascimento(request.getDataNascimento());
+        paciente.setResponsavel(request.getResponsavel());
+        paciente.setConvenio(convenio);
+        paciente.setUnidade(request.getUnidade());
+        paciente.setCreatedBy(currentUser);
+
+        Paciente savedPaciente = pacienteRepository.save(paciente);
+        logger.info("Paciente criado com sucesso: {}", savedPaciente.getId());
+
+        return mapToPacienteDto(savedPaciente);
+    }
+
+    @Override
+    @Transactional
+    public PacienteDto updatePaciente(UUID id, PacienteUpdateRequest request) {
+        logger.info("Atualizando paciente com ID: {}", id);
+
+       Paciente paciente = pacienteRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado com ID: " + id));
+
+       if (request.getNome() != null) {
+           paciente.setNome(request.getNome());
+       }
+
+       if (request.getDataNascimento() != null) {
+              paciente.setDataNascimento(request.getDataNascimento());
+       }
+
+       if (request.getResponsavel() != null) {
+           paciente.setResponsavel(request.getResponsavel());
+       }
+
+       if (request.getConvenioId() != null) {
+           Convenio convenio = convenioRepository.findById(request.getConvenioId())
+                   .orElseThrow(() -> new ResourceNotFoundException("Convênio não encontrado com ID: " + request.getConvenioId()));
+           paciente.setConvenio(convenio);;
+       }
+
+       if (request.getUnidade() != null) {
+           paciente.setUnidade(request.getUnidade());
+       }
+
+       Paciente updatedPaciente = pacienteRepository.save(paciente);
+       logger.info("Paciente atualizado com sucesso. ID: {}", updatedPaciente.getId());
+
+       return mapToPacienteDto(updatedPaciente);
+    }
+
+    @Override
+    public void deletePaciente(UUID id) {
+        logger.info("Excluindo paciente com ID: {}", id);
+
+        if (!pacienteRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Paciente não encontrado com ID: " + id);
+        }
+
+        long totalGuias = pacienteRepository.countGuiasByPacienteId(id);
+        if (totalGuias > 0) {
+            throw new IllegalStateException("Não é possível excluir paciente com guias associadas. Total de guias: " + totalGuias);
+        }
+
+        pacienteRepository.deleteById(id);
+        logger.info("Paciente deletado com sucesso. ID: {}", id);
+    }
+
+    @Override
+    public Page<PacienteSummaryDto> searchPacientesByNome(String nome, Pageable pageable) {
+        logger.info("Buscando pacientes por nome: ", nome);
+
+        Page<Paciente> pacientes = pacienteRepository.findByNomeContainingIgnoreCase(nome, pageable);
+        return pacientes.map(this::mapToPacienteSummaryDto);
+    }
+
+    @Override
+    public Page<PacienteSummaryDto> getPacientesByConvenio(UUID convenioId, Pageable pageable) {
+        logger.info("Buscando pacientes por convênio ID: {}", convenioId);
+
+        Page<Paciente> pacientes = pacienteRepository.findByConvenioId(convenioId, pageable);
+        return pacientes.map(this::mapToPacienteSummaryDto);
+    }
+
+    @Override
+    public Page<PacienteSummaryDto> getPacientesByUnidade(Paciente.UnidadeEnum unidade, Pageable pageable) {
+        logger.info("Buscando pacientes por unidade: {}", unidade);
+
+        Page<Paciente> pacientes = pacienteRepository.findByUnidade(unidade, pageable);
+        return pacientes.map(this::mapToPacienteSummaryDto);
+    }
+
+    @Override
+    public Page<PacienteSummaryDto> getPacientesByDataNascimento(LocalDate startDate, LocalDate endDate, Pageable pageable) {
+        logger.info("Buscando pacientes por data de nascimento entre {} e {}", startDate, endDate);
+
+        Page<Paciente> pacientes = pacienteRepository.findByDataNascimentoBetween(startDate, endDate, pageable);
+        return pacientes.map(this::mapToPacienteSummaryDto);
+    }
+
+    @Override
+    public Page<GuiaSummaryDto> getGuiasByPacienteId(UUID pacienteId, Pageable pageable) {
+        logger.info("Buscando guias do paciente: {}", pacienteId);
+
+        if (!pacienteRepository.existsById(pacienteId)) {
+            throw new ResourceNotFoundException("Paciente não encontrado com ID: " + pacienteId);
+        }
+
+        return guiaRepository.findByPacienteId(pacienteId, pageable)
+                .map(this::mapToGuiaSummaryDto);
+    }
+
+    @Override
+    public long countTotalPacientes() {
+        return pacienteRepository.count();
+    }
+
+    @Override
+    public long countPacientesByConvenio(UUID convenioId) {
+        return pacienteRepository.findByConvenioId(convenioId, Pageable.unpaged()).getTotalElements();
+    }
+
+    @Override
+    public long countPacientesByUnidade(Paciente.UnidadeEnum unidade) {
+        return pacienteRepository.findByUnidade(unidade, Pageable.unpaged()).getTotalElements();
+    }
+
+    // Métodos auxiliares de mapeamento
+    private User getCurrentUser() {
+        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado: " + userDetails.getUsername()));
+    }
+
+    private PacienteDto mapToPacienteDto(Paciente paciente) {
+        long totalGuias = pacienteRepository.countGuiasByPacienteId(paciente.getId());
+
+        return new PacienteDto(
+                paciente.getId(),
+                paciente.getNome(),
+                paciente.getDataNascimento(),
+                paciente.getResponsavel(),
+                paciente.getConvenio().getId(),
+                paciente.getConvenio().getName(),
+                paciente.getUnidade(),
+                paciente.getCreatedBy().getId(),
+                paciente.getCreatedBy().getFullName(),
+                paciente.getCreatedAt(),
+                paciente.getUpdatedAt(),
+                totalGuias
+        );
+    }
+
+    private PacienteSummaryDto mapToPacienteSummaryDto(Paciente paciente) {
+        long totalGuias = pacienteRepository.countGuiasByPacienteId(paciente.getId());
+        boolean hasGuiasVencidas = pacienteRepository.hasGuiasVencidas(paciente.getId());
+
+        return new PacienteSummaryDto(
+                paciente.getId(),
+                paciente.getNome(),
+                paciente.getDataNascimento(),
+                paciente.getConvenio().getName(),
+                paciente.getUnidade(),
+                totalGuias,
+                hasGuiasVencidas
+        );
+    }
+
+    private GuiaSummaryDto mapToGuiaSummaryDto(Guia guia) {
+        long totalFichas = guiaRepository.countFichasByGuiaId(guia.getId());
+
+        return new GuiaSummaryDto(
+                guia.getId(),
+                guia.getPaciente().getNome(),
+                guia.getEspecialidades(),
+                guia.getQuantidadeAutorizada(),
+                guia.getConvenio().getName(),
+                guia.getMes(),
+                guia.getAno(),
+                guia.getValidade(),
+                guia.getQuantidadeFaturada(),
+                guia.getValorReais(),
+                guia.getUsuarioResponsavel().getFullName(),
+                totalFichas,
+                guia.isVencida(),
+                guia.isQuantidadeExcedida()
+        );
+    }
+
+}

--- a/apps/backend/src/main/java/com/intranet/backend/util/DTOMapperUtil.java
+++ b/apps/backend/src/main/java/com/intranet/backend/util/DTOMapperUtil.java
@@ -181,6 +181,175 @@ public class DTOMapperUtil {
         return dto;
     }
 
+    /**
+     * Mapeia um paciente para um DTO de paciente
+     */
+    public static PacienteDto mapToPacienteDto(Paciente paciente, long totalGuias) {
+        return new PacienteDto(
+                paciente.getId(),
+                paciente.getNome(),
+                paciente.getDataNascimento(),
+                paciente.getResponsavel(),
+                paciente.getConvenio().getId(),
+                paciente.getConvenio().getName(),
+                paciente.getUnidade(),
+                paciente.getCreatedBy().getId(),
+                paciente.getCreatedBy().getFullName(),
+                paciente.getCreatedAt(),
+                paciente.getUpdatedAt(),
+                totalGuias
+        );
+    }
+
+    /**
+     * Mapeia um paciente para um DTO de resumo de paciente
+     */
+    public static PacienteSummaryDto mapToPacienteSummaryDto(Paciente paciente, long totalGuias, boolean hasGuiasVencidas) {
+        return new PacienteSummaryDto(
+                paciente.getId(),
+                paciente.getNome(),
+                paciente.getDataNascimento(),
+                paciente.getConvenio().getName(),
+                paciente.getUnidade(),
+                totalGuias,
+                hasGuiasVencidas
+        );
+    }
+
+    /**
+     * Mapeia uma guia para um DTO de guia
+     */
+    public static GuiaDto mapToGuiaDto(Guia guia, long totalFichas) {
+        return new GuiaDto(
+                guia.getId(),
+                guia.getPaciente().getId(),
+                guia.getPaciente().getNome(),
+                guia.getEspecialidades(),
+                guia.getQuantidadeAutorizada(),
+                guia.getConvenio().getId(),
+                guia.getConvenio().getName(),
+                guia.getMes(),
+                guia.getAno(),
+                guia.getValidade(),
+                guia.getLote(),
+                guia.getQuantidadeFaturada(),
+                guia.getValorReais(),
+                guia.getUsuarioResponsavel().getId(),
+                guia.getUsuarioResponsavel().getFullName(),
+                guia.getCreatedAt(),
+                guia.getUpdatedAt(),
+                totalFichas,
+                guia.isVencida(),
+                guia.isQuantidadeExcedida(),
+                guia.getQuantidadeRestante()
+        );
+    }
+
+    /**
+     * Mapeia uma guia para um DTO de resumo de guia
+     */
+    public static GuiaSummaryDto mapToGuiaSummaryDto(Guia guia, long totalFichas) {
+        return new GuiaSummaryDto(
+                guia.getId(),
+                guia.getPaciente().getNome(),
+                guia.getEspecialidades(),
+                guia.getQuantidadeAutorizada(),
+                guia.getConvenio().getName(),
+                guia.getMes(),
+                guia.getAno(),
+                guia.getValidade(),
+                guia.getQuantidadeFaturada(),
+                guia.getValorReais(),
+                guia.getUsuarioResponsavel().getFullName(),
+                totalFichas,
+                guia.isVencida(),
+                guia.isQuantidadeExcedida()
+        );
+    }
+
+    /**
+     * Mapeia uma ficha para um DTO de ficha
+     */
+    public static FichaDto mapToFichaDto(Ficha ficha) {
+        return new FichaDto(
+                ficha.getId(),
+                ficha.getGuia().getId(),
+                ficha.getPacienteNome(),
+                ficha.getEspecialidade(),
+                ficha.getQuantidadeAutorizada(),
+                ficha.getConvenio().getId(),
+                ficha.getConvenioNome(),
+                ficha.getMes(),
+                ficha.getAno(),
+                ficha.getUsuarioResponsavel().getId(),
+                ficha.getUsuarioResponsavel().getFullName(),
+                ficha.getCreatedAt(),
+                ficha.getUpdatedAt()
+        );
+    }
+
+    /**
+     * Mapeia uma ficha para um DTO de resumo de ficha
+     */
+    public static FichaSummaryDto mapToFichaSummaryDto(Ficha ficha) {
+        return new FichaSummaryDto(
+                ficha.getId(),
+                ficha.getPacienteNome(),
+                ficha.getEspecialidade(),
+                ficha.getQuantidadeAutorizada(),
+                ficha.getConvenioNome(),
+                ficha.getMes(),
+                ficha.getAno(),
+                ficha.getUsuarioResponsavel().getFullName(),
+                ficha.getCreatedAt()
+        );
+    }
+
+    /**
+     * Mapeia uma página de pacientes para uma página de DTOs de resumo
+     */
+    public static Page<PacienteSummaryDto> mapToPacienteSummaryDtoPage(Page<Paciente> page) {
+        return page.map(paciente -> {
+            return new PacienteSummaryDto(
+                    paciente.getId(),
+                    paciente.getNome(),
+                    paciente.getDataNascimento(),
+                    paciente.getConvenio().getName(),
+                    paciente.getUnidade(),
+                    0L, // totalGuias - deve ser calculado no serviço
+                    false // hasGuiasVencidas - deve ser calculado no serviço
+            );
+        });
+    }
+
+    /**
+     * Mapeia uma página de guias para uma página de DTOs de resumo
+     */
+    public static Page<GuiaSummaryDto> mapToGuiaSummaryDtoPage(Page<Guia> page) {
+        return page.map(guia -> new GuiaSummaryDto(
+                guia.getId(),
+                guia.getPaciente().getNome(),
+                guia.getEspecialidades(),
+                guia.getQuantidadeAutorizada(),
+                guia.getConvenio().getName(),
+                guia.getMes(),
+                guia.getAno(),
+                guia.getValidade(),
+                guia.getQuantidadeFaturada(),
+                guia.getValorReais(),
+                guia.getUsuarioResponsavel().getFullName(),
+                0L, // totalFichas - deve ser calculado no serviço
+                guia.isVencida(),
+                guia.isQuantidadeExcedida()
+        ));
+    }
+
+    /**
+     * Mapeia uma página de fichas para uma página de DTOs de resumo
+     */
+    public static Page<FichaSummaryDto> mapToFichaSummaryDtoPage(Page<Ficha> page) {
+        return page.map(DTOMapperUtil::mapToFichaSummaryDto);
+    }
 
     /**
      * Extrai o nome do arquivo de uma URL

--- a/apps/backend/src/main/resources/db/migration/V21__add_clinical_management_tables.sql
+++ b/apps/backend/src/main/resources/db/migration/V21__add_clinical_management_tables.sql
@@ -1,0 +1,126 @@
+-- V21__add_clinical_management_tables.sql
+
+-- Tabela de Pacientes
+CREATE TABLE pacientes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    nome VARCHAR(255) NOT NULL,
+    data_nascimento DATE NOT NULL,
+    responsavel VARCHAR(255),
+    convenio_id UUID NOT NULL REFERENCES convenios(id) ON DELETE RESTRICT,
+    unidade VARCHAR(10) NOT NULL CHECK (unidade IN ('KIDS', 'SENIOR')),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Tabela de Guias
+CREATE TABLE guias (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    paciente_id UUID NOT NULL REFERENCES pacientes(id) ON DELETE CASCADE,
+    especialidades TEXT[] NOT NULL, -- Array de especialidades
+    quantidade_autorizada INTEGER NOT NULL CHECK (quantidade_autorizada > 0),
+    convenio_id UUID NOT NULL REFERENCES convenios(id) ON DELETE RESTRICT,
+    mes INTEGER NOT NULL CHECK (mes BETWEEN 1 AND 12),
+    ano INTEGER NOT NULL CHECK (ano >= 2020),
+    validade DATE NOT NULL,
+    lote VARCHAR(100),
+    quantidade_faturada INTEGER NOT NULL DEFAULT 0 CHECK (quantidade_faturada >= 0),
+    valor_reais DECIMAL(10,2) NOT NULL DEFAULT 0.00 CHECK (valor_reais >= 0),
+    usuario_responsavel UUID NOT NULL REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tabela de Fichas
+CREATE TABLE fichas (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    guia_id UUID NOT NULL REFERENCES guias(id) ON DELETE CASCADE,
+    especialidade VARCHAR(100) NOT NULL,
+    quantidade_autorizada INTEGER NOT NULL CHECK (quantidade_autorizada > 0),
+    convenio_id UUID NOT NULL REFERENCES convenios(id) ON DELETE RESTRICT,
+    mes INTEGER NOT NULL CHECK (mes BETWEEN 1 AND 12),
+    ano INTEGER NOT NULL CHECK (ano >= 2020),
+    usuario_responsavel UUID NOT NULL REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Constraint para garantir que uma ficha tenha apenas uma guia
+    UNIQUE(guia_id, especialidade)
+);
+
+-- Índices para melhorar performance
+CREATE INDEX idx_pacientes_nome ON pacientes(nome);
+CREATE INDEX idx_pacientes_convenio_id ON pacientes(convenio_id);
+CREATE INDEX idx_pacientes_unidade ON pacientes(unidade);
+CREATE INDEX idx_pacientes_data_nascimento ON pacientes(data_nascimento);
+
+CREATE INDEX idx_guias_paciente_id ON guias(paciente_id);
+CREATE INDEX idx_guias_convenio_id ON guias(convenio_id);
+CREATE INDEX idx_guias_mes_ano ON guias(mes, ano);
+CREATE INDEX idx_guias_validade ON guias(validade);
+CREATE INDEX idx_guias_usuario_responsavel ON guias(usuario_responsavel);
+
+CREATE INDEX idx_fichas_guia_id ON fichas(guia_id);
+CREATE INDEX idx_fichas_convenio_id ON fichas(convenio_id);
+CREATE INDEX idx_fichas_especialidade ON fichas(especialidade);
+CREATE INDEX idx_fichas_mes_ano ON fichas(mes, ano);
+CREATE INDEX idx_fichas_usuario_responsavel ON fichas(usuario_responsavel);
+
+-- Adicionar novas permissões para o módulo clínico
+INSERT INTO permissions (name, description)
+VALUES
+    ('paciente:create', 'Permissão para criar pacientes'),
+    ('paciente:read', 'Permissão para ler dados de pacientes'),
+    ('paciente:update', 'Permissão para atualizar dados de pacientes'),
+    ('paciente:delete', 'Permissão para excluir pacientes'),
+    ('guia:create', 'Permissão para criar guias'),
+    ('guia:read', 'Permissão para ler guias'),
+    ('guia:update', 'Permissão para atualizar guias'),
+    ('guia:delete', 'Permissão para excluir guias'),
+    ('ficha:create', 'Permissão para criar fichas'),
+    ('ficha:read', 'Permissão para ler fichas'),
+    ('ficha:update', 'Permissão para atualizar fichas'),
+    ('ficha:delete', 'Permissão para excluir fichas');
+
+-- Atribuir permissões aos papéis existentes
+
+-- Administradores têm todas as permissões
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT
+    (SELECT id FROM roles WHERE name = 'ADMIN'),
+    id
+FROM permissions
+WHERE name LIKE 'paciente:%' OR name LIKE 'guia:%' OR name LIKE 'ficha:%';
+
+-- Supervisores têm todas as permissões clínicas
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT
+    (SELECT id FROM roles WHERE name = 'SUPERVISOR'),
+    id
+FROM permissions
+WHERE name LIKE 'paciente:%' OR name LIKE 'guia:%' OR name LIKE 'ficha:%';
+
+-- Gerentes têm todas as permissões clínicas
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT
+    (SELECT id FROM roles WHERE name = 'GERENTE'),
+    id
+FROM permissions
+WHERE name LIKE 'paciente:%' OR name LIKE 'guia:%' OR name LIKE 'ficha:%';
+
+-- Editores podem criar e editar, mas não excluir
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT
+    (SELECT id FROM roles WHERE name = 'EDITOR'),
+    id
+FROM permissions
+WHERE name LIKE 'paciente:create' OR name LIKE 'paciente:read' OR name LIKE 'paciente:update'
+   OR name LIKE 'guia:create' OR name LIKE 'guia:read' OR name LIKE 'guia:update'
+   OR name LIKE 'ficha:create' OR name LIKE 'ficha:read' OR name LIKE 'ficha:update';
+
+-- Usuários comuns podem apenas ler
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT
+    (SELECT id FROM roles WHERE name = 'USER'),
+    id
+FROM permissions
+WHERE name LIKE 'paciente:read' OR name LIKE 'guia:read' OR name LIKE 'ficha:read';


### PR DESCRIPTION
This pull request introduces three new controllers (`FichaController`, `GuiaController`, and `PacienteController`) and several DTOs to manage `Ficha`, `Guia`, and `Paciente` entities in the backend application. These changes add comprehensive CRUD operations, filtering, and statistics endpoints for these entities, along with corresponding data transfer objects for request and response handling.

### Controllers Implementation:
* **`FichaController`**: Implements endpoints for managing `Ficha` entities, including CRUD operations, filtering by various attributes (e.g., `guiaId`, `pacienteId`, `convenioId`, etc.), and retrieving statistics.
* **`GuiaController`**: Provides endpoints for managing `Guia` entities, including CRUD operations, filtering by attributes (e.g., `pacienteId`, `convenioId`, etc.), and retrieving related `Ficha` entities and statistics.
* **`PacienteController`**: Adds endpoints for managing `Paciente` entities, including CRUD operations, filtering by attributes (e.g., `convenioId`, `unidade`, etc.), and retrieving associated `Guia` entities and statistics. Includes temporary debug logging for user authentication details.

### DTOs for `Ficha` Entity:
* **`FichaCreateRequest`**: Defines validation rules for creating a `Ficha`, including required fields like `guiaId`, `especialidade`, and `quantidadeAutorizada`.
* **`FichaDto`**: Represents detailed information about a `Ficha` for responses, including fields like `id`, `guiaId`, `pacienteNome`, and timestamps.
* **`FichaSummaryDto`**: Provides a summarized view of a `Ficha` for list responses, focusing on key attributes like `pacienteNome`, `especialidade`, and `convenioNome`.
* **`FichaUpdateRequest`**: Defines optional fields for updating a `Ficha`, with validation rules for attributes like `especialidade` and `quantidadeAutorizada`.