### PR TITLE
update: regra de negocio guia única por mês

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
@@ -62,4 +62,7 @@ public interface GuiaRepository extends JpaRepository<Guia, UUID> {
 
     @Query("SELECT g FROM Guia g WHERE g.status LIKE %:status% ORDER BY g.createdAt DESC")
     Page<Guia> findGuiaByStatus(@Param("status") String status, Pageable pageable);
+
+    @Query("SELECT COUNT(g) > 0 FROM Guia g WHERE g.numeroGuia = :numero AND g.mes = :mes AND g.ano = :ano")
+    boolean existsByNumeroGuiaAndMesAndAno(@Param("numero") String numeroGuia, @Param("mes") Integer mes, @Param("ano") Integer ano);
 }

--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/GuiaServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/GuiaServiceImpl.java
@@ -59,8 +59,8 @@ public class GuiaServiceImpl implements GuiaService {
         Convenio convenio = convenioRepository.findById(request.getConvenioId())
                 .orElseThrow(() -> new ResourceNotFoundException("Convênio com ID: " + request.getConvenioId()));
 
-        if (guiaRepository.existsByNumeroGuia(request.getNumeroGuia())) {
-            throw new IllegalArgumentException("Já existe uma guia com o número: " + request.getNumeroGuia());
+        if (guiaRepository.existsByNumeroGuiaAndMesAndAno(request.getNumeroGuia(), request.getMes(), request.getAno())) {
+            throw new IllegalArgumentException("Já existe guia com número " + request.getNumeroGuia() + " para o período " + request.getMes() + "/" + request.getAno());
         }
 
         Guia guia = new Guia();


### PR DESCRIPTION
This pull request introduces changes to enhance the validation logic for creating `Guia` entities by incorporating month and year checks. The most significant updates involve adding a new repository method and modifying the service layer to use this method for more granular validation.

### Repository Updates:
* Added a new query method `existsByNumeroGuiaAndMesAndAno` in `GuiaRepository` to check for the existence of a `Guia` entity based on its number, month, and year. This improves the precision of validation checks.

### Service Layer Updates:
* Updated the `createGuia` method in `GuiaServiceImpl` to use the newly added `existsByNumeroGuiaAndMesAndAno` method for validating `Guia` creation. This ensures that duplicate entries are prevented for a specific period (month/year) rather than solely based on the `numeroGuia`.