### PR TITLE
update: novos campos de dados nos relatórios

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/dto/RelatorioItemDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/RelatorioItemDto.java
@@ -8,34 +8,56 @@ import java.util.UUID;
 @Data
 public class RelatorioItemDto {
 
-    // Identificação
-    private String tipoEntidade; //GUIA, FICHA, PACIENTE
+    private String tipoEntidade; // GUIA, FICHA
     private UUID entidadeId;
-
-    // Informações do paciente
     private String pacienteNome;
     private UUID pacienteId;
-
-    // Informações da guia
+    private String convenioNome;
     private String numeroGuia;
     private UUID guiaId;
-
-    // Informações da ficha
     private String codigoFicha;
     private UUID fichaId;
 
-    // Informações gerais
-    private String convenioNome;
+    // Método helper para obter número/código unificado
+    public String getNumeroOuCodigo() {
+        if ("GUIA".equals(tipoEntidade) && numeroGuia != null) {
+            return numeroGuia;
+        } else if ("FICHA".equals(tipoEntidade) && codigoFicha != null) {
+            return codigoFicha;
+        }
+        return "-";
+    }
+
     private String status;
     private String especialidade;
-    private String unidade;
     private Integer mes;
     private Integer ano;
+
+    // Método helper para obter mês formatado
+    public String getMesFormatado() {
+        if (mes != null && ano != null) {
+            return String.format("%02d/%d", mes, ano);
+        }
+        return "-";
+    }
+
     private Integer quantidadeAutorizada;
-    private String usuarioResponsavelNome;
+
+    // Método helper para quantidade formatada
+    public String getQuantidadeFormatada() {
+        if (quantidadeAutorizada != null) {
+            return quantidadeAutorizada.toString();
+        }
+        return "-";
+    }
+
     private LocalDateTime dataAtualizacao;
 
-    // Informações de mudança de status
+    // Outros campos auxiliares
+    private String unidade;
+    private String usuarioResponsavelNome;
+
+    // Campos para histórico de mudanças
     private String statusAnterior;
     private String statusNovo;
     private String motivoMudanca;

--- a/apps/frontend/src/app/relatorios/[id]/page.tsx
+++ b/apps/frontend/src/app/relatorios/[id]/page.tsx
@@ -1,4 +1,3 @@
-// apps/frontend/src/app/relatorios/[id]/page.tsx
 "use client";
 
 import React, { useState, useEffect } from "react";
@@ -47,6 +46,7 @@ import {
   ArcElement,
 } from "chart.js";
 import { Bar, Pie } from "react-chartjs-2";
+import { StatusBadge as SystemStatusBadge } from "@/components/clinical/ui/StatusBadge";
 
 // Registrar componentes do Chart.js
 ChartJS.register(
@@ -225,39 +225,65 @@ export default function RelatorioDetalhesPage() {
   // Colunas para tabela de dados
   const dadosColumns = [
     {
-      header: "Tipo",
-      accessor: "tipoEntidade" as keyof RelatorioItemDto,
-      className: "font-medium",
-    },
-    {
-      header: "Paciente",
+      header: "Nome do Paciente",
       accessor: "pacienteNome" as keyof RelatorioItemDto,
-    },
-    {
-      header: "Código/Número",
-      accessor: ((item: RelatorioItemDto) =>
-        item.numeroGuia || item.codigoFicha || "-") as any,
+      className: "font-medium",
     },
     {
       header: "Convênio",
       accessor: "convenioNome" as keyof RelatorioItemDto,
     },
     {
+      header: "Número/Código",
+      accessor: ((item: RelatorioItemDto) =>
+        item.numeroGuia || item.codigoFicha || "-") as any,
+      className: "font-mono text-sm",
+    },
+    {
       header: "Status",
-      accessor: "status" as keyof RelatorioItemDto,
+      accessor: ((item: RelatorioItemDto) => (
+        <SystemStatusBadge status={item.status} size="sm" variant="default" />
+      )) as any,
     },
     {
       header: "Especialidade",
       accessor: "especialidade" as keyof RelatorioItemDto,
     },
     {
-      header: "Responsável",
-      accessor: "usuarioResponsavelNome" as keyof RelatorioItemDto,
+      header: "Mês",
+      accessor: ((item: RelatorioItemDto) => {
+        if (item.mes && item.ano) {
+          return `${item.mes.toString().padStart(2, "0")}/${item.ano}`;
+        }
+        return "-";
+      }) as any,
+      className: "text-center",
+    },
+    {
+      header: "Qtd. Autorizada",
+      accessor: ((item: RelatorioItemDto) =>
+        item.quantidadeAutorizada?.toString() || "-") as any,
+      className: "text-center",
     },
     {
       header: "Atualização",
       accessor: ((item: RelatorioItemDto) =>
         formatDateTime(item.dataAtualizacao)) as any,
+      className: "text-sm",
+    },
+    {
+      header: "Tipo",
+      accessor: ((item: RelatorioItemDto) => (
+        <span
+          className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+            item.tipoEntidade === "GUIA"
+              ? "bg-purple-100 text-purple-800"
+              : "bg-indigo-100 text-indigo-800"
+          }`}>
+          {item.tipoEntidade}
+        </span>
+      )) as any,
+      className: "text-center",
     },
   ];
 

--- a/apps/frontend/src/types/relatorio.ts
+++ b/apps/frontend/src/types/relatorio.ts
@@ -78,23 +78,23 @@ export interface RelatorioSummaryDto {
 }
 
 export interface RelatorioItemDto {
-  tipoEntidade: string; // GUIA, FICHA, PACIENTE
+  tipoEntidade: string; // GUIA, FICHA
   entidadeId: string;
   pacienteNome?: string;
   pacienteId?: string;
+  convenioNome?: string;
   numeroGuia?: string;
   guiaId?: string;
   codigoFicha?: string;
   fichaId?: string;
-  convenioNome?: string;
   status: string;
   especialidade?: string;
-  unidade?: string;
   mes?: number;
   ano?: number;
   quantidadeAutorizada?: number;
-  usuarioResponsavelNome?: string;
   dataAtualizacao: string;
+  unidade?: string;
+  usuarioResponsavelNome?: string;
   statusAnterior?: string;
   statusNovo?: string;
   motivoMudanca?: string;
@@ -150,3 +150,38 @@ export interface RelatorioEstatisticas {
   compartilhamentosEnviados: number;
   ultimoRelatorio?: RelatorioSummaryDto;
 }
+
+export const relatorioItemHelpers = {
+  getNumeroOuCodigo: (item: RelatorioItemDto): string => {
+    if (item.tipoEntidade === "GUIA" && item.numeroGuia) {
+      return item.numeroGuia;
+    } else if (item.tipoEntidade === "FICHA" && item.codigoFicha) {
+      return item.codigoFicha;
+    }
+    return "-";
+  },
+
+  getMesFormatado: (item: RelatorioItemDto): string => {
+    if (item.mes && item.ano) {
+      return `${item.mes.toString().padStart(2, "0")}/${item.ano}`;
+    }
+    return "-";
+  },
+
+  getQuantidadeFormatada: (item: RelatorioItemDto): string => {
+    return item.quantidadeAutorizada?.toString() || "-";
+  },
+
+  formatDataAtualizacao: (dataString: string): string => {
+    try {
+      const data = new Date(dataString);
+      return (
+        data.toLocaleDateString("pt-BR") +
+        " " +
+        data.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })
+      );
+    } catch {
+      return "-";
+    }
+  },
+};


### PR DESCRIPTION
This pull request includes significant updates to the backend and frontend components of the reporting system, focusing on improving the PDF generation process, optimizing data mapping, and enhancing the user interface. Key changes include restructuring the `RelatorioItemDto` class, updating the PDF generation logic, and introducing reusable helper methods for formatting. Additionally, frontend changes include the integration of a new `StatusBadge` component.

### Backend Changes

#### Enhancements to `RelatorioItemDto`:
* Added helper methods `getNumeroOuCodigo`, `getMesFormatado`, and `getQuantidadeFormatada` for unified and formatted data retrieval.
* Removed unused fields and reorganized the class to improve clarity and maintainability.

#### PDF Generation Improvements:
* Updated date formatting for the report period and generation date using `DateTimeFormatter`.
* Redesigned the table structure in the PDF to include nine columns with a more detailed layout, and increased the item limit from 100 to 500 for better coverage.
* Introduced auxiliary methods like `getNumeroOuCodigoPDF`, `getMesFormatadoPDF`, and `createHeaderCell` to streamline PDF data formatting.

#### Data Mapping Optimizations:
* Simplified the mapping logic in `mapGuiaToRelatorioItem` and `mapFichaToRelatorioItem` by removing redundant code and ensuring cleaner handling of patient and specialty data. [[1]](diffhunk://#diff-f1e0fa28acb9a5da5cf95e445db2d89f3debd1c66cdf3fb85956c81e489c3e8fL916) [[2]](diffhunk://#diff-f1e0fa28acb9a5da5cf95e445db2d89f3debd1c66cdf3fb85956c81e489c3e8fL979-L1005)
* Removed the `enrichItemWithEntityData` method, consolidating its functionality into the mapping methods for better performance and reduced complexity.

### Frontend Changes

#### UI Enhancements:
* Integrated the `StatusBadge` component from the clinical UI library to improve status visualization in reports. ([apps/frontend/src/app/relatorios/[id]/page.tsxR49](diffhunk://#diff-d0b13dcbd7466002f5dacced407fed41687ca5a08f4d041e3eca3a4b4ea3f5b6R49))