### PR TITLE
update: correção do repository

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/repository/FichaRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/FichaRepository.java
@@ -100,15 +100,12 @@ public interface FichaRepository extends JpaRepository<Ficha, UUID> {
         if (unidades != null && !unidades.isEmpty()) {
             fichas = fichas.stream()
                     .filter(ficha -> {
-                        if (ficha.getGuia() == null || ficha.getGuia().getPaciente() == null) {
-                            return false;
-                        }
+                        if (ficha.getGuia() == null) return false;
+                        if (ficha.getGuia().getPaciente() == null) return false;
                         try {
                             String unidadePaciente = ficha.getGuia().getPaciente().getUnidade().name();
                             return unidades.contains(unidadePaciente);
                         } catch (Exception e) {
-                            logger.warn("Erro ao verificar unidade da ficha {}: {}",
-                                    ficha.getId(), e.getMessage());
                             return false;
                         }
                     })

--- a/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
+++ b/apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java
@@ -79,31 +79,11 @@ public interface GuiaRepository extends JpaRepository<Guia, UUID> {
             "AND (:status IS NULL OR g.status IN :status) " +
             "AND (:convenioIds IS NULL OR g.convenio.id IN :convenioIds) " +
             "ORDER BY g.updatedAt DESC")
-    List<Guia> findGuiasForRelatorio(
-            @Param("usuarioResponsavel") UUID usuarioResponsavel,
-            @Param("periodoInicio") LocalDateTime periodoInicio,
-            @Param("periodoFim") LocalDateTime periodoFim,
-            @Param("status") List<String> status,
-            @Param("convenioIds") List<UUID> convenioIds
-    );
-
-    @Query("SELECT DISTINCT g FROM Guia g " +
-            "LEFT JOIN FETCH g.paciente p " +
-            "LEFT JOIN FETCH g.convenio c " +
-            "LEFT JOIN FETCH g.usuarioResponsavel u " +
-            "WHERE (:usuarioResponsavel IS NULL OR g.usuarioResponsavel.id = :usuarioResponsavel) " +
-            "AND (g.createdAt BETWEEN :periodoInicio AND :periodoFim " +
-            "     OR g.updatedAt BETWEEN :periodoInicio AND :periodoFim) " +
-            "AND (:status IS NULL OR g.status IN :status) " +
-            "AND (:convenioIds IS NULL OR g.convenio.id IN :convenioIds) " +
-            "AND (:especialidades IS NULL OR EXISTS (SELECT 1 FROM g.especialidades esp WHERE esp IN :especialidades)) " +
-            "ORDER BY g.updatedAt DESC")
     List<Guia> findGuiasForRelatorioBase(
             @Param("usuarioResponsavel") UUID usuarioResponsavel,
             @Param("periodoInicio") LocalDateTime periodoInicio,
             @Param("periodoFim") LocalDateTime periodoFim,
             @Param("status") List<String> status,
-            @Param("especialidades") List<String> especialidades,
             @Param("convenioIds") List<UUID> convenioIds
     );
 
@@ -116,7 +96,7 @@ public interface GuiaRepository extends JpaRepository<Guia, UUID> {
                                              List<String> unidades) {
 
         List<Guia> guias = findGuiasForRelatorioBase(
-                usuarioResponsavel, periodoInicio, periodoFim, status, especialidades, convenioIds
+                usuarioResponsavel, periodoInicio, periodoFim, status, convenioIds
         );
 
         // Aplicar filtros de especialidades


### PR DESCRIPTION
This pull request refactors repository methods in `FichaRepository` and `GuiaRepository` to streamline logic and remove redundant code. The changes focus on improving code readability, reducing complexity, and eliminating unused parameters.

### Code simplification and readability improvements:

* [`apps/backend/src/main/java/com/intranet/backend/repository/FichaRepository.java`](diffhunk://#diff-52fa9901259f533ee58619579bf5023d368e4ec1d0fd9b194b27bfe8b8ff2c49L103-L111): Simplified conditional checks in the `findFichasForRelatorio` method by separating `null` checks for `ficha.getGuia()` and `ficha.getGuia().getPaciente()` into individual statements. Removed unnecessary logging in the exception handling block.

* [`apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java`](diffhunk://#diff-c2a26c4e1f806fbbda4d14933f8109122abbb7fa379f0013ec9af3d170aa77efL82-L106): Removed the unused `findGuiasForRelatorio` query method and its associated query definition. This reduces redundancy and ensures only the `findGuiasForRelatorioBase` method is used for fetching `Guia` data.

### Parameter cleanup:

* [`apps/backend/src/main/java/com/intranet/backend/repository/GuiaRepository.java`](diffhunk://#diff-c2a26c4e1f806fbbda4d14933f8109122abbb7fa379f0013ec9af3d170aa77efL119-R99): Updated the `findGuiasForRelatorio` method to remove the `especialidades` parameter when calling `findGuiasForRelatorioBase`, as it is no longer used in the query.