### PR TITLE
update: calculo de progresso

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfJobDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfJobDto.java
@@ -11,6 +11,7 @@ public class FichaPdfJobDto {
     private String status;
     private Integer totalFichas;
     private Integer fichasProcessadas;
+    private Integer progresso;
     private LocalDateTime iniciado;
     private LocalDateTime concluido;
     private Boolean podeDownload;

--- a/apps/backend/src/main/java/com/intranet/backend/service/FichaVerificationService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/FichaVerificationService.java
@@ -27,7 +27,7 @@ public class FichaVerificationService {
 
     private final FichaRepository fichaRepository;
     private final ConvenioRepository convenioRepository;
-    
+
     // Cache local para otimizar verificações repetidas na mesma sessão
     private final Map<String, Boolean> verificacaoCache = new ConcurrentHashMap<>();
 

--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfServiceImpl.java
@@ -1358,6 +1358,14 @@ public class FichaPdfServiceImpl implements FichaPdfService {
         dto.setPodeDownload(job.isPodeDownload());
         dto.setObservacoes(job.getObservacoes());
 
+        // ✅ CORREÇÃO: Calcular progresso da mesma forma que no mapJobToStatus
+        if (job.getTotalFichas() != null && job.getTotalFichas() > 0 && job.getFichasProcessadas() != null) {
+            int progresso = (int) ((double) job.getFichasProcessadas() / job.getTotalFichas() * 100);
+            dto.setProgresso(progresso);
+        } else {
+            dto.setProgresso(0);
+        }
+
         if (job.isPodeDownload()) {
             dto.setDownloadUrl("/api/fichas-pdf/download/" + job.getJobId());
         }


### PR DESCRIPTION
This pull request introduces a new feature to track the progress of PDF generation jobs and ensures consistency in progress calculation. The most important changes include adding a `progresso` field to the `FichaPdfJobDto` class and implementing logic to calculate and set this progress value in the `mapJobToDto` method.

### New feature: Progress tracking for PDF jobs
* Added a new field `progresso` to the `FichaPdfJobDto` class to represent the progress percentage of PDF generation jobs. (`apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfJobDto.java`, [apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfJobDto.javaR14](diffhunk://#diff-155d96bd905ee599eb849a22a9881b49b600769f81c6c9d069ab0bfa00888baaR14))
* Implemented logic in the `mapJobToDto` method to calculate the progress percentage based on the number of processed and total fichas. This calculation ensures consistency with the `mapJobToStatus` method and defaults to 0 if the total number of fichas is not available or is zero. (`apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfServiceImpl.java`, [apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfServiceImpl.javaR1361-R1368](diffhunk://#diff-e09ba51f9f1bbf09554bc0d1d37999ffadc3f90060d94413bb3d49fd14f2882fR1361-R1368))