### PR TITLE
update: geração de template por convênio

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfItemDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfItemDto.java
@@ -17,6 +17,7 @@ public class FichaPdfItemDto {
     private UUID convenioId;
     private String convenioNome;
     private String unidade;
+    private String htmlGerado;
 
     // Dados da guia de origem
     private UUID guiaId;

--- a/apps/backend/src/main/java/com/intranet/backend/service/FichaPdfTemplateService.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/FichaPdfTemplateService.java
@@ -16,6 +16,14 @@ public interface FichaPdfTemplateService {
     String gerarHtmlComTemplate(FichaPdfItemDto item, String templateNome);
 
     /**
+     * NOVO: Gera HTML com template específico para um convênio
+     * @param item Dados da ficha
+     * @param convenioNome Nome do convênio (ex: "FUSEX", "CBMDF")
+     * @return HTML completo da ficha
+     */
+    String gerarHtmlComTemplateConvenio(FichaPdfItemDto item, String convenioNome);
+
+    /**
      * Obtém template padrão
      */
     String getTemplatePadrao();
@@ -24,4 +32,11 @@ public interface FichaPdfTemplateService {
      * Converte imagem para base64
      */
     String imagemParaBase64(String caminhoImagem);
+
+    /**
+     * Valida se existe template específico para um convênio
+     * @param convenioNome Nome do convênio
+     * @return true se existe template específico
+     */
+    boolean temTemplateEspecifico(String convenioNome);
 }

--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfServiceImpl.java
@@ -37,7 +37,6 @@ public class FichaPdfServiceImpl implements FichaPdfService {
     private final FichaPdfJobRepository jobRepository;
     private final ConvenioFichaPdfConfigRepository configRepository;
     private final FichaPdfLogRepository logRepository;
-    private final FichaRepository fichaRepository;
     private final UserRepository userRepository;
     private final PacienteRepository pacienteRepository;
     private final GuiaRepository guiaRepository;
@@ -1162,11 +1161,27 @@ public class FichaPdfServiceImpl implements FichaPdfService {
             if (guia.getEspecialidades() != null && !guia.getEspecialidades().isEmpty()) {
                 for (String especialidade : guia.getEspecialidades()) {
                     FichaPdfItemDto item = criarItemFicha(guia, especialidade, mes, ano);
+
+                    // NOVO: Gerar HTML usando template específico do convênio
+                    String convenioNome = guia.getConvenio() != null ? guia.getConvenio().getName() : null;
+                    String htmlGerado = templateService.gerarHtmlComTemplateConvenio(item, convenioNome);
+
+                    // Armazenar o HTML no item para uso posterior
+                    item.setHtmlGerado(htmlGerado);
+
                     itens.add(item);
                 }
             } else {
                 // Criar ficha sem especialidade específica
                 FichaPdfItemDto item = criarItemFicha(guia, "Não informado", mes, ano);
+
+                // NOVO: Gerar HTML usando template específico do convênio
+                String convenioNome = guia.getConvenio() != null ? guia.getConvenio().getName() : null;
+                String htmlGerado = templateService.gerarHtmlComTemplateConvenio(item, convenioNome);
+
+                // Armazenar o HTML no item para uso posterior
+                item.setHtmlGerado(htmlGerado);
+
                 itens.add(item);
             }
         }


### PR DESCRIPTION
This pull request introduces support for generating custom HTML templates for specific health insurance agreements (convênios), with an initial implementation for the "FUSEX" agreement. The changes allow the system to generate and store agreement-specific HTML in each `FichaPdfItemDto`, and provide a mechanism to check for and use these custom templates when available.

**Support for agreement-specific PDF templates:**

* Added a new field `htmlGerado` to `FichaPdfItemDto` to store the generated HTML for each item.
* Updated `FichaPdfServiceImpl` so that, when processing guides (`Guia`), it generates and stores HTML using an agreement-specific template via the new `gerarHtmlComTemplateConvenio` method.

**Template service enhancements:**

* Extended `FichaPdfTemplateService` with two new methods: `gerarHtmlComTemplateConvenio` for generating HTML with an agreement-specific template, and `temTemplateEspecifico` to check if a specific agreement has a custom template. [[1]](diffhunk://#diff-384f11bed4192c84c6cefcb607c0c2872a6ec5f227295a63f067a7778359f700R18-R25) [[2]](diffhunk://#diff-384f11bed4192c84c6cefcb607c0c2872a6ec5f227295a63f067a7778359f700R35-R41)
* Implemented `gerarHtmlComTemplateConvenio` in `FichaPdfTemplateServiceImpl`, which uses a custom template for "FUSEX" and defaults to the standard template for others. Also implemented `temTemplateEspecifico` to recognize "FUSEX" as the only agreement with a custom template for now. [[1]](diffhunk://#diff-40e616de9d2f6e7f83b2ee8e46a6260577a159950fa6bb62294d62e495a3b45cR78-R101) [[2]](diffhunk://#diff-40e616de9d2f6e7f83b2ee8e46a6260577a159950fa6bb62294d62e495a3b45cR111-R125)

**Custom FUSEX template:**

* Added a new private method `criarTemplateFusex` in `FichaPdfTemplateServiceImpl` containing the full HTML and CSS for the "FUSEX" agreement, based on the legacy PHP system.

**Refactoring:**

* Removed the unused `FichaRepository` field from `FichaPdfServiceImpl` to clean up the code.