### PR TITLE
Develop

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfTemplateServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfTemplateServiceImpl.java
@@ -616,139 +616,99 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Ficha de Assinatura - {NUMERO_IDENTIFICACAO}</title>
+        <title>Ficha de Assinatura</title>
         <style>
             body {
                 font-family: Arial, sans-serif;
                 font-size: 12px;
                 margin: 5px;
             }
-            
             .header {
-                display: table;
-                width: 100%;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
                 margin-bottom: 10px;
             }
-            
-            .header-cell {
-                display: table-cell;
-                vertical-align: middle;
-            }
-
-            .header-left {
-                width: 150px;
-                text-align: left;
-            }
-
-            .header-center {
-                text-align: center;
-            }
-
-            .header-right {
-                width: 150px;
-                text-align: right;
-            }
-            
             .header img {
                 width: 150px;
                 height: auto;
             }
-            
             .header h1 {
                 font-size: 18px;
                 margin: 0;
                 text-align: center;
+                flex-grow: 1;
             }
-            
             .header .identificacao {
                 font-size: 14px;
                 font-weight: bold;
             }
-            
             .section {
                 margin-bottom: 5px;
             }
-            
             .section label {
                 display: inline-block;
                 width: 200px;
                 font-weight: bold;
             }
-            
             .table {
                 width: 100%;
                 border-collapse: collapse;
-                margin-top: 15px;
             }
-            
             .table th, .table td {
                 border: 1px solid #000;
                 padding: 5px;
                 text-align: center;
             }
-            
-            .table th {
-                background-color: #f0f0f0;
-                font-weight: bold;
-            }
-            
             .info-header {
                 text-align: left;
-                margin-bottom: 15px;
+                margin-bottom: 5px;
             }
-            
-            /* Específico para CBMDF */
-            .cbmdf-header {
-                border-bottom: 2px solid #d32f2f; /* Cor vermelha dos bombeiros */
-                padding-bottom: 10px;
+            .footer {
+                 margin-top: 20px;
+                 padding: 10px;
+                 border-top: 1px solid #ccc;
+                 font-size: 11px;
             }
-            
-            .cbmdf-instructions {
-                background-color: #ffebee; /* Fundo levemente avermelhado */
-                border: 1px solid #d32f2f;
-                border-radius: 4px;
-                padding: 10px;
-                margin-top: 20px;
-                font-size: 10px;
-                font-style: italic;
+            .footer p {
+                 margin: 3px 0;
             }
-            
-            .cbmdf-header h1 {
-                color: #d32f2f; /* Título em vermelho */
-            }
-            
             .metadata {
-                margin-top: 20px;
-                font-size: 10px;
-                font-style: italic;
+                  margin-top: 15px;
+                  padding: 8px;
+                  background-color: #f9f9f9;
+                  border: 1px solid #ddd;
+                  font-size: 10px;
+                  text-align: center;
+            }
+            .metadata span {
+                   margin: 0 15px;
+                   color: #666;
             }
         </style>
     </head>
     <body>
-        <div class="header cbmdf-header">
-            <div class="header-cell header-left">
-                <img src="{LOGO_BASE64}" alt="Logo CBMDF">
-            </div>
-            <div class="header-cell header-center">
-                <h1>FICHA DE ASSINATURA</h1>
-            </div>
-            <div class="header-cell header-right">
-                <div class="identificacao">ID: {NUMERO_IDENTIFICACAO}</div>
-            </div>
+        <div class="header">
+            <img src="{LOGO_BASE64}" alt="Logo">
+            <h1>FICHA DE ASSINATURA</h1>
+            <div class="identificacao">ID: {NUMERO_IDENTIFICACAO}</div>
         </div>
 
         <div class="info-header">
             <div class="section">
-                <label>Nome do Paciente:</label> {PACIENTE_NOME}
+                <label>Paciente:</label> {PACIENTE_NOME}
             </div>
             <div class="section">
                 <label>Especialidade:</label> {ESPECIALIDADE}
             </div>
             <div class="section">
-                <label>Mês:</label> {MES_EXTENSO}
+                <label>Mês de referência:</label> {MES_EXTENSO}
             </div>
             <div class="section">
-                <label>Convênio:</label> CBMDF
+                <label>Convênio:</label> {CONVENIO_NOME}
+            </div>
+            <div class="section">
+                <label>Quantidade Autorizada:</label> {QUANTIDADE_AUTORIZADA} sessões
             </div>
         </div>
 
@@ -764,20 +724,16 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
                 {LINHAS_TABELA}
             </tbody>
         </table>
-        
-        <div class="cbmdf-instructions">
-            <p><strong>Instruções CBMDF:</strong></p>
-            <p>1. Preencher a data e assinar a cada atendimento realizado.</p>
-            <p>2. Este documento é de uso obrigatório para faturamento junto ao CBMDF.</p>
-            <p>3. Manter o documento em local seguro e apresentar quando solicitado.</p>
-            <p>4. Em caso de dúvidas, entrar em contato com o setor administrativo.</p>
-        </div>
-
-        <div class="metadata">
-            <span>Gerado em: {DATA_GERACAO}</span>
-            <span>Guia: {NUMERO_GUIA}</span>
-            <span>Sistema: Intranet v2.0</span>
-        </div>
+         <div class="footer">
+               <p><strong>Instruções:</strong></p>
+               <p>1. Preencher a data e assinar a cada atendimento realizado.</p>
+               <p>2. Este documento é de uso obrigatório para faturamento junto ao convênio.</p>
+               <p>3. Manter o documento em local seguro e apresentar quando solicitado.</p>
+         </div>
+         <div class="metadata">
+                <span>Gerado em: {DATA_GERACAO}</span>
+                <span>Sistema: Intranet v2.0</span>
+         </div>
     </body>
     </html>
     """;

--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfTemplateServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfTemplateServiceImpl.java
@@ -689,7 +689,7 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
     </head>
     <body>
         <div class="header">
-            <img src="{LOGO_BASE64}" alt="Logo">
+            <img src="{LOGO_BASE64}" alt="logo-cbmdf">
             <h1>FICHA DE ASSINATURA</h1>
             <div class="identificacao">ID: {NUMERO_IDENTIFICACAO}</div>
         </div>

--- a/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfTemplateServiceImpl.java
+++ b/apps/backend/src/main/java/com/intranet/backend/service/impl/FichaPdfTemplateServiceImpl.java
@@ -88,6 +88,9 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
                 logger.info("✅ FUSEX identificado! Convênio: '{}' - Usando template específico", convenioNome);
                 String templateFusex = obterTemplateFusex();
                 return preencherTemplate(templateFusex, item);
+            } else if (isCbmdfConvenio(convenioNome)) {
+                String templateCbmdf = obterTemplateCbmdf();
+                return preencherTemplate(templateCbmdf, item);
             }
 
             // Para outros convênios, usar template padrão
@@ -130,6 +133,10 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
                     logger.info("✅ FUSEX identificado! Convênio: '{}' - Usando template específico", convenioNome);
                     String templateFusex = obterTemplateFusex();
                     return preencherTemplateComConvenio(templateFusex, item, config);
+                } else if (isCbmdfConvenio(convenioNome)) {
+                    logger.info("✅ CBMDF identificado! Convênio: '{}' - Usando template específico", convenioNome);
+                    String templateCbmdf = obterTemplateCbmdf();
+                    return preencherTemplateComConvenio(templateCbmdf, item, config);
                 }
             }
 
@@ -144,6 +151,33 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
             logger.warn("Usando template padrão como fallback");
             return gerarHtmlFicha(item);
         }
+    }
+
+    private boolean isCbmdfConvenio(String convenioNome) {
+        if (convenioNome == null) return false;
+
+        String nome = convenioNome.toUpperCase().trim();
+
+        String[] variacoesCbmdf = {
+                "CBMDF",
+                "CORPO DE BOMBEIROS",
+                "CORPO DE BOMBEIROS MILITAR",
+                "CORPO DE BOMBEIROS DF",
+                "CORPO DE BOMBEIROS DISTRITO FEDERAL",
+                "CBMDF - CORPO DE BOMBEIROS",
+                "BOMBEIROS DF",
+                "BOMBEIROS MILITAR DF",
+        };
+
+        for (String variacao : variacoesCbmdf) {
+            if (nome.contains(variacao)) {
+                logger.debug("✅ Convênio '{}' identificado como CBMDF (variação '{}')", convenioNome, variacao);
+                return true;
+            }
+        }
+
+        logger.debug("❌ Convênio '{}' não é CBMDF", convenioNome);
+        return false;
     }
 
     private boolean isFusexConvenio(String convenioNome) {
@@ -184,6 +218,13 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
         });
     }
 
+    private String obterTemplateCbmdf() {
+        return templateCache.computeIfAbsent("template_cbmdf", k -> {
+            logger.debug("Carregando template do CBMDF");
+            return criarTemplateCbmdf();
+        });
+    }
+
     private String obterTemplateFusex() {
         return templateCache.computeIfAbsent("template_fusex", k -> {
             logger.debug("Carregando template do FUSEX");
@@ -210,13 +251,14 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
         }
 
         // Fallback: usar a lógica atual baseada no nome
-        return isFusexConvenio(config.getConvenio().getName());
+        String convenioNome = config.getConvenio().getName();
+        return isFusexConvenio(convenioNome) || isCbmdfConvenio(convenioNome);
     }
 
     @Override
     public boolean temTemplateEspecifico(String convenioNome) {
         if (convenioNome == null) return false;
-        return isFusexConvenio(convenioNome);
+        return isFusexConvenio(convenioNome) || isCbmdfConvenio(convenioNome);
     }
 
     /**
@@ -561,6 +603,184 @@ public class FichaPdfTemplateServiceImpl implements FichaPdfTemplateService {
     </body>
     </html>
      """;
+    }
+
+    /**
+     * Template específico para o Cbmdf
+     * Baseado no sistema legado em PHP
+     */
+    private String criarTemplateCbmdf() {
+        return """
+    <!DOCTYPE html>
+    <html lang="pt-BR">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Ficha de Assinatura - {NUMERO_IDENTIFICACAO}</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                font-size: 12px;
+                margin: 5px;
+            }
+            
+            .header {
+                display: table;
+                width: 100%;
+                margin-bottom: 10px;
+            }
+            
+            .header-cell {
+                display: table-cell;
+                vertical-align: middle;
+            }
+
+            .header-left {
+                width: 150px;
+                text-align: left;
+            }
+
+            .header-center {
+                text-align: center;
+            }
+
+            .header-right {
+                width: 150px;
+                text-align: right;
+            }
+            
+            .header img {
+                width: 150px;
+                height: auto;
+            }
+            
+            .header h1 {
+                font-size: 18px;
+                margin: 0;
+                text-align: center;
+            }
+            
+            .header .identificacao {
+                font-size: 14px;
+                font-weight: bold;
+            }
+            
+            .section {
+                margin-bottom: 5px;
+            }
+            
+            .section label {
+                display: inline-block;
+                width: 200px;
+                font-weight: bold;
+            }
+            
+            .table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 15px;
+            }
+            
+            .table th, .table td {
+                border: 1px solid #000;
+                padding: 5px;
+                text-align: center;
+            }
+            
+            .table th {
+                background-color: #f0f0f0;
+                font-weight: bold;
+            }
+            
+            .info-header {
+                text-align: left;
+                margin-bottom: 15px;
+            }
+            
+            /* Específico para CBMDF */
+            .cbmdf-header {
+                border-bottom: 2px solid #d32f2f; /* Cor vermelha dos bombeiros */
+                padding-bottom: 10px;
+            }
+            
+            .cbmdf-instructions {
+                background-color: #ffebee; /* Fundo levemente avermelhado */
+                border: 1px solid #d32f2f;
+                border-radius: 4px;
+                padding: 10px;
+                margin-top: 20px;
+                font-size: 10px;
+                font-style: italic;
+            }
+            
+            .cbmdf-header h1 {
+                color: #d32f2f; /* Título em vermelho */
+            }
+            
+            .metadata {
+                margin-top: 20px;
+                font-size: 10px;
+                font-style: italic;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="header cbmdf-header">
+            <div class="header-cell header-left">
+                <img src="{LOGO_BASE64}" alt="Logo CBMDF">
+            </div>
+            <div class="header-cell header-center">
+                <h1>FICHA DE ASSINATURA</h1>
+            </div>
+            <div class="header-cell header-right">
+                <div class="identificacao">ID: {NUMERO_IDENTIFICACAO}</div>
+            </div>
+        </div>
+
+        <div class="info-header">
+            <div class="section">
+                <label>Nome do Paciente:</label> {PACIENTE_NOME}
+            </div>
+            <div class="section">
+                <label>Especialidade:</label> {ESPECIALIDADE}
+            </div>
+            <div class="section">
+                <label>Mês:</label> {MES_EXTENSO}
+            </div>
+            <div class="section">
+                <label>Convênio:</label> CBMDF
+            </div>
+        </div>
+
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Nº</th>
+                    <th>Data de Atendimento</th>
+                    <th>Assinatura do Responsável</th>
+                </tr>
+            </thead>
+            <tbody>
+                {LINHAS_TABELA}
+            </tbody>
+        </table>
+        
+        <div class="cbmdf-instructions">
+            <p><strong>Instruções CBMDF:</strong></p>
+            <p>1. Preencher a data e assinar a cada atendimento realizado.</p>
+            <p>2. Este documento é de uso obrigatório para faturamento junto ao CBMDF.</p>
+            <p>3. Manter o documento em local seguro e apresentar quando solicitado.</p>
+            <p>4. Em caso de dúvidas, entrar em contato com o setor administrativo.</p>
+        </div>
+
+        <div class="metadata">
+            <span>Gerado em: {DATA_GERACAO}</span>
+            <span>Guia: {NUMERO_GUIA}</span>
+            <span>Sistema: Intranet v2.0</span>
+        </div>
+    </body>
+    </html>
+    """;
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for generating a specific PDF template for the CBMDF (Corpo de Bombeiros Militar do Distrito Federal) health plan, similar to the existing handling for FUSEX. The changes include detection logic for CBMDF, the addition of a new HTML template, and updates to methods that determine which template to use.

**CBMDF Template Support:**

* Added a new method `criarTemplateCbmdf` that defines a dedicated HTML template for CBMDF, closely matching the legacy PHP system.
* Implemented `obterTemplateCbmdf` to efficiently load and cache the CBMDF template.

**Convenio Detection and Template Selection:**

* Introduced `isCbmdfConvenio`, a method to robustly detect CBMDF plan names using various possible name variations.
* Updated the template selection logic in `gerarHtmlComTemplateConvenio` and `gerarHtmlComConfiguracaoConvenio` to use the CBMDF template when a CBMDF plan is detected. [[1]](diffhunk://#diff-40e616de9d2f6e7f83b2ee8e46a6260577a159950fa6bb62294d62e495a3b45cR91-R93) [[2]](diffhunk://#diff-40e616de9d2f6e7f83b2ee8e46a6260577a159950fa6bb62294d62e495a3b45cR136-R139)
* Modified `temTemplateEspecificoPorConfig` and `temTemplateEspecifico` to return `true` for both FUSEX and CBMDF plans, ensuring the correct template is used for these cases.