### PR TITLE
update: correção do método de verificar pacientes

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/controllers/FichaPdfController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/FichaPdfController.java
@@ -465,13 +465,19 @@ public class FichaPdfController {
                     "totalFichas", fichasExistentes.size(),
                     "fichasPorEspecialidade", fichasPorEspecialidade,
                     "fichasExistentes", fichasExistentes.stream()
-                            .map(f -> Map.of(
-                                    "id", f.getId(),
-                                    "codigo", f.getCodigoFicha(),
-                                    "especialidade", f.getEspecialidade(),
-                                    "status", f.getStatus(),
-                                    "criadaEm", f.getCreatedAt()
-                            ))
+                            .map(f -> {
+                                Map<String, Object> fichaMap = new HashMap<>();
+                                fichaMap.put("id", f.getId());
+                                fichaMap.put("codigo", f.getCodigoFicha() != null ? f.getCodigoFicha() : "N/A");
+                                fichaMap.put("especialidade", f.getEspecialidade() != null ? f.getEspecialidade() : "Não informada");
+                                fichaMap.put("status", f.getStatus() != null ? f.getStatus() : "Pendente");
+                                fichaMap.put("mes", f.getMes() != null ? f.getMes() : mes);
+                                fichaMap.put("ano", f.getAno() != null ? f.getAno() : ano);
+                                fichaMap.put("criadaEm", f.getCreatedAt());
+                                fichaMap.put("numeroIdentificacao", f.getCodigoFicha() != null ? f.getCodigoFicha() : "Pendente");
+                                fichaMap.put("dataGeracao", f.getCreatedAt() != null ? f.getCreatedAt().toString() : "N/A");
+                                return fichaMap;
+                            })
                             .collect(Collectors.toList()),
                     "recomendacao", fichasExistentes.isEmpty() ?
                             "Paciente precisa de fichas para este período" :


### PR DESCRIPTION
This pull request updates the response mapping logic in the `verificarFichasPaciente` method of `FichaPdfController.java` to provide more robust and informative data for each ficha (record). The new implementation ensures that fields are never null in the API response by supplying default values when necessary, and it adds new fields to the ficha representation.

Enhancements to ficha response mapping:

* Replaced the use of `Map.of` with a more flexible `HashMap` to allow conditional and default values for each field, ensuring no nulls are returned in the API response.
* Added new fields to each ficha in the response: `mes`, `ano`, `numeroIdentificacao`, and `dataGeracao`, using either the ficha's data or sensible defaults.
* Provided default values for existing fields (`codigo`, `especialidade`, `status`, etc.) when their values are missing, improving the consistency and reliability of the API output.