### PR TITLE
update: correção de fluxos no backend

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/config/JacksonConfig.java
+++ b/apps/backend/src/main/java/com/intranet/backend/config/JacksonConfig.java
@@ -1,0 +1,32 @@
+package com.intranet.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Configuração do Jackson para serialização/deserialização adequada de datas
+ */
+@Configuration
+public class JacksonConfig {
+
+    public static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATETIME_FORMAT);
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return Jackson2ObjectMapperBuilder.json()
+                .modules(new JavaTimeModule())
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .serializers(new LocalDateTimeSerializer(DATE_TIME_FORMATTER))
+                .build();
+    }
+}

--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfJobDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfJobDto.java
@@ -1,5 +1,6 @@
 package com.intranet.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -12,8 +13,13 @@ public class FichaPdfJobDto {
     private Integer totalFichas;
     private Integer fichasProcessadas;
     private Integer progresso;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime iniciado;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime concluido;
+
     private Boolean podeDownload;
     private String downloadUrl;
     private String observacoes;
@@ -38,6 +44,7 @@ public class FichaPdfJobDto {
         return podeDownload != null ? podeDownload : false;
     }
 
+    // Getter para jobId com valor padrão
     public String getJobId() {
         return jobId != null ? jobId : "";
     }

--- a/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfStatusDto.java
+++ b/apps/backend/src/main/java/com/intranet/backend/dto/FichaPdfStatusDto.java
@@ -1,5 +1,6 @@
 package com.intranet.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.intranet.backend.model.FichaPdfJob;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,35 +13,72 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class FichaPdfStatusDto {
     private String jobId;
-    private FichaPdfJob.StatusJob status;
-    private FichaPdfJob.TipoGeracao tipo;
+    private FichaPdfJob.StatusJob status; // Enum direto para serialização correta
+    private FichaPdfJob.TipoGeracao tipo; // Enum direto para serialização correta
     private String mensagem;
     private Integer progresso; // 0-100
-    private Integer totalItens;
-    private Integer itensProcessados;
+    private Integer totalItens; // Nome do campo no DTO original
+    private Integer itensProcessados; // Nome do campo no DTO original
     private Integer fichasReutilizadas;
     private Integer fichasNovas;
     private Integer duplicatasEvitadas;
-    private LocalDateTime iniciadoEm;
-    private LocalDateTime atualizadoEm;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime iniciadoEm; // Nome do campo no DTO original
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime atualizadoEm; // Nome do campo no DTO original
+
     private String observacoes;
     private Boolean podeDownload;
-
     private String usuarioNome;
     private String usuarioEmail;
-
     private DadosJobDto dadosJob;
+
+    // Getters com valores padrão para evitar nulls
+    public Integer getTotalItens() {
+        return totalItens != null ? totalItens : 0;
+    }
+
+    public Integer getItensProcessados() {
+        return itensProcessados != null ? itensProcessados : 0;
+    }
+
+    public Integer getProgresso() {
+        return progresso != null ? progresso : 0;
+    }
+
+    public Boolean getPodeDownload() {
+        return podeDownload != null ? podeDownload : false;
+    }
 
     @Data
     public static class DadosJobDto {
-        private String convenioNome;
         private String convenioId;
-        private String pacienteNome;
+        private String convenioNome;
         private String pacienteId;
+        private String pacienteNome;
         private Integer mes;
         private Integer ano;
         private String mesExtenso;
         private String periodo;
+        private String especialidade;
+        private Integer quantidadeAutorizada;
         private Integer totalConvenios;
+
+        // Métodos auxiliares
+        public String getPeriodoFormatado() {
+            if (mes != null && ano != null) {
+                return String.format("%02d/%d", mes, ano);
+            }
+            return periodo != null ? periodo : "-";
+        }
+
+        public String getMesExtensoFormatado() {
+            if (mesExtenso != null && ano != null) {
+                return String.format("%s/%d", mesExtenso, ano);
+            }
+            return getPeriodoFormatado();
+        }
     }
 }

--- a/apps/frontend/src/types/fichaPdf.ts
+++ b/apps/frontend/src/types/fichaPdf.ts
@@ -365,16 +365,82 @@ export const fichaPdfHelpers = {
     return `${meses[mes - 1]} ${ano}`;
   },
 
-  formatarDataHora: (dataString: string): string => {
+  formatarDataHora: (dataString: string | null | undefined): string => {
+    if (!dataString) {
+      return "Não informado";
+    }
+
+    try {
+      // Se a string está vazia ou é inválida
+      if (typeof dataString !== "string" || dataString.trim() === "") {
+        return "Não informado";
+      }
+
+      // Tentar criar data a partir da string
+      const data = new Date(dataString);
+
+      // Verificar se a data é válida
+      if (isNaN(data.getTime())) {
+        console.warn("Data inválida recebida:", dataString);
+        return "Data inválida";
+      }
+
+      // Formatar data em português brasileiro
+      const dataFormatada = data.toLocaleDateString("pt-BR");
+      const horaFormatada = data.toLocaleTimeString("pt-BR", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+
+      return `${dataFormatada} às ${horaFormatada}`;
+    } catch (error) {
+      console.error(
+        "Erro ao formatar data:",
+        error,
+        "Data recebida:",
+        dataString
+      );
+      return "Erro ao formatar data";
+    }
+  },
+
+  isDataValida: (dataString: string | null | undefined): boolean => {
+    if (
+      !dataString ||
+      typeof dataString !== "string" ||
+      dataString.trim() === ""
+    ) {
+      return false;
+    }
+
     try {
       const data = new Date(dataString);
-      return (
-        data.toLocaleDateString("pt-BR") +
-        " às " +
-        data.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })
-      );
+      return !isNaN(data.getTime());
     } catch {
-      return "-";
+      return false;
+    }
+  },
+
+  formatarData: (dataString: string | null | undefined): string => {
+    if (!dataString) {
+      return "Não informado";
+    }
+
+    try {
+      if (typeof dataString !== "string" || dataString.trim() === "") {
+        return "Não informado";
+      }
+
+      const data = new Date(dataString);
+
+      if (isNaN(data.getTime())) {
+        return "Data inválida";
+      }
+
+      return data.toLocaleDateString("pt-BR");
+    } catch (error) {
+      console.error("Erro ao formatar data:", error);
+      return "Erro ao formatar data";
     }
   },
 


### PR DESCRIPTION
This pull request introduces improvements to date/time handling and data robustness for the Ficha PDF job/status flows, both in the backend and frontend. The main focus is on consistent date serialization/deserialization, null safety, and improved formatting and validation of date fields.

**Backend: Date Serialization, DTO Enhancements, and Null Safety**

* Added a global Jackson configuration (`JacksonConfig.java`) to ensure all `LocalDateTime` fields are serialized/deserialized in the `yyyy-MM-dd'T'HH:mm:ss` format, avoiding issues with timestamps.
* Annotated relevant `LocalDateTime` fields in `FichaPdfJobDto` and `FichaPdfStatusDto` with `@JsonFormat` for explicit date format control. [[1]](diffhunk://#diff-155d96bd905ee599eb849a22a9881b49b600769f81c6c9d069ab0bfa00888baaR3) [[2]](diffhunk://#diff-155d96bd905ee599eb849a22a9881b49b600769f81c6c9d069ab0bfa00888baaR16-R22) [[3]](diffhunk://#diff-ab4ee3cc55359ef2a8eaa6a9ea1d45b8f4c196f9e63ea8560d9d5874b277b802R3) [[4]](diffhunk://#diff-ab4ee3cc55359ef2a8eaa6a9ea1d45b8f4c196f9e63ea8560d9d5874b277b802L15-R82)
* Enhanced DTOs (`FichaPdfJobDto`, `FichaPdfStatusDto`) and their mapping logic to provide default values for potentially null fields (e.g., integers default to 0, booleans to false, strings to empty), reducing frontend null checks and improving API reliability. [[1]](diffhunk://#diff-155d96bd905ee599eb849a22a9881b49b600769f81c6c9d069ab0bfa00888baaR47) [[2]](diffhunk://#diff-ab4ee3cc55359ef2a8eaa6a9ea1d45b8f4c196f9e63ea8560d9d5874b277b802L15-R82) [[3]](diffhunk://#diff-e09ba51f9f1bbf09554bc0d1d37999ffadc3f90060d94413bb3d49fd14f2882fR1658-R1684) [[4]](diffhunk://#diff-e09ba51f9f1bbf09554bc0d1d37999ffadc3f90060d94413bb3d49fd14f2882fR1794-L1803)
* Improved calculation of progress and error messages in the status DTO to handle edge cases and avoid division by zero or null pointer exceptions. [[1]](diffhunk://#diff-e09ba51f9f1bbf09554bc0d1d37999ffadc3f90060d94413bb3d49fd14f2882fR1658-R1684) [[2]](diffhunk://#diff-e09ba51f9f1bbf09554bc0d1d37999ffadc3f90060d94413bb3d49fd14f2882fL1687-R1711) [[3]](diffhunk://#diff-e09ba51f9f1bbf09554bc0d1d37999ffadc3f90060d94413bb3d49fd14f2882fR1794-L1803)

**Frontend: Date Formatting and Validation Helpers**

* Enhanced `fichaPdfHelpers` with robust date formatting and validation methods (`formatarDataHora`, `formatarData`, `isDataValida`) to gracefully handle null, empty, or invalid date strings, providing user-friendly messages and avoiding runtime errors.

These changes together ensure more reliable and user-friendly handling of date/time information throughout the Ficha PDF job workflow.