### PR TITLE
Develop

### DIFF
--- a/apps/backend/src/main/java/com/intranet/backend/controllers/GuiaController.java
+++ b/apps/backend/src/main/java/com/intranet/backend/controllers/GuiaController.java
@@ -196,18 +196,33 @@ public class GuiaController {
             @RequestParam String termo,
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        Page<GuiaSummaryDto> guias = guiaService.searchByNumeroGuia(termo, pageable);
-        return ResponseEntity.ok(guias);
+        logger.info("Buscando guias por número/termo: {}", termo);
+
+        try {
+            if (termo == null || termo.trim().isEmpty()) {
+                logger.warn("Termo de busca vazio recebido para guias");
+                return ResponseEntity.badRequest().build();
+            }
+
+            Page<GuiaSummaryDto> guias = guiaService.searchByNumeroGuia(termo.trim(), pageable);
+
+            logger.info("Encontradas {} guias para o termo: {}", guias.getTotalElements(), termo);
+
+            return ResponseUtil.success(guias);
+        } catch (Exception e) {
+            logger.error("Erro ao buscar guias por número: {}", e.getMessage(), e);
+            throw e;
+        }
     }
 
-    @GetMapping("/status/status")
+    @GetMapping("/status/{status}")
     public ResponseEntity<Page<GuiaSummaryDto>> getGuiasByStatus(
-            @RequestParam String status,
+            @PathVariable String status,
             @PageableDefault(size = 20) Pageable pageable) {
         logger.info("Requisição para buscar guias com status: {}", status);
 
         Page<GuiaSummaryDto> guias = guiaService.getGuiasByStatus(status, pageable);
-        return ResponseEntity.ok(guias);
+        return ResponseUtil.success(guias);
     }
 
     @GetMapping("/{id}/historico-status")

--- a/apps/frontend/src/app/fichas/page.tsx
+++ b/apps/frontend/src/app/fichas/page.tsx
@@ -134,20 +134,27 @@ export default function FichasPage() {
       setLoading(true);
       const query = searchQuery || searchTerm;
 
+      console.log("searchFichas chamado com query:", query); // Debug
+
       if (query.trim() === "") {
         loadFichas();
         return;
       }
 
       const fichasData = await fichaService.searchByCodigoFicha(
-        query,
+        query.trim(), // Garantir que não há espaços extras
         currentPage,
         20
       );
+
+      console.log("Resultado da busca:", fichasData); // Debug
       setFichas(fichasData);
     } catch (err) {
       console.error("Erro ao buscar fichas:", err);
       toastUtil.error("Erro ao buscar fichas");
+
+      // Em caso de erro, mostrar lista completa
+      loadFichas();
     } finally {
       setLoading(false);
     }
@@ -167,14 +174,25 @@ export default function FichasPage() {
   };
 
   const handleSearch = (term: string) => {
-    setSearchTerm(term);
+    console.log("handleSearch chamado com termo:", term); // Debug
+
+    // Limpar filtros quando iniciar busca
+    setSelectedConvenio("");
+    setSelectedStatus("");
+    setSelectedEspecialidade("");
     setCurrentPage(0);
 
-    if (term.trim() !== "") {
-      searchFichas(term);
-    } else {
+    // Atualizar estado do termo de busca
+    setSearchTerm(term);
+
+    // Se o termo está vazio, recarregar lista completa
+    if (term.trim() === "") {
       loadFichas();
+      return;
     }
+
+    // Caso contrário, fazer busca por código
+    searchFichas(term);
   };
 
   const handleVincularGuia = (ficha: FichaSummaryDto) => {

--- a/apps/frontend/src/components/clinical/ui/SearchInput.tsx
+++ b/apps/frontend/src/components/clinical/ui/SearchInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Search, X } from "lucide-react";
 
 interface SearchInputProps {
@@ -22,7 +22,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
 }) => {
   const [internalValue, setInternalValue] = useState(value);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setInternalValue(value);
   }, [value]);
 
@@ -35,8 +35,9 @@ export const SearchInput: React.FC<SearchInputProps> = ({
     }
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && onEnterSearch) {
+      e.preventDefault();
       onChange(internalValue);
     }
   };
@@ -58,7 +59,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         type="text"
         value={internalValue}
         onChange={handleInputChange}
-        onKeyPress={handleKeyPress}
+        onKeyDown={handleKeyDown}
         placeholder={placeholder}
         className="block w-full pl-10 pr-10 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
       />

--- a/apps/frontend/src/services/clinical.ts
+++ b/apps/frontend/src/services/clinical.ts
@@ -360,7 +360,7 @@ export const fichaService = {
     size: number = 20
   ): Promise<PageResponse<FichaSummaryDto>> {
     const response = await api.get(
-      `/api/fichas/search-codigo?termo=${codigoFicha}&page=${page}&size=${size}`
+      `/api/fichas/search/codigo?termo=${encodeURIComponent(codigoFicha)}&page=${page}&size=${size}`
     );
     return response.data;
   },


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to search and filtering functionality for "guias" and "fichas" in both the backend and frontend. The main changes include improved error handling, clearer separation of search and filter logic, enhanced logging for debugging, and some API adjustments. These updates aim to provide a more robust and user-friendly experience when searching and filtering data.

**Backend improvements and API changes:**

* Improved error handling and logging in the `GuiaController` for the `searchByNumero` endpoint, including returning a bad request for empty search terms and using a unified `ResponseUtil.success` response wrapper. The `/status/{status}` endpoint now uses a path variable instead of a query parameter.

**Frontend: Search and filter logic improvements**

* In `FichasPage` and `GuiasPage`, the search handlers now clear filters when a new search is initiated, trim whitespace from search terms, and reload the full list on error or when the search term is empty. Additional debug logging has been added to help trace search operations. [[1]](diffhunk://#diff-10224af858a19b3ddfc50d6498c39d8c85f0fd83fb8217c77ea7ecd6eb7c6d30R137-R157) [[2]](diffhunk://#diff-10224af858a19b3ddfc50d6498c39d8c85f0fd83fb8217c77ea7ecd6eb7c6d30L170-R195) [[3]](diffhunk://#diff-e629984e69f112635d20fdbad088759ef2533c8e8da19e9138043c73ef00a687R142-R191)
* In `GuiasPage`, the data loading logic now prioritizes filters (convenio, status, periodo) in a mutually exclusive manner, and only loads all guias if no filters are applied.

**Frontend: UI and component enhancements**

* The `SearchInput` component now uses `onKeyDown` instead of `onKeyPress` for handling the Enter key, prevents default form submission, and ensures the input value is kept in sync with props. [[1]](diffhunk://#diff-54a12d375ea6b088fd3042841b47e37a08eb9d4d227094ef8573a16511bd1a2cL3-R3) [[2]](diffhunk://#diff-54a12d375ea6b088fd3042841b47e37a08eb9d4d227094ef8573a16511bd1a2cL25-R25) [[3]](diffhunk://#diff-54a12d375ea6b088fd3042841b47e37a08eb9d4d227094ef8573a16511bd1a2cL38-R40) [[4]](diffhunk://#diff-54a12d375ea6b088fd3042841b47e37a08eb9d4d227094ef8573a16511bd1a2cL61-R62)

**Frontend: API adjustments**

* The `fichaService.searchByCodigoFicha` method now uses the correct URL and encodes the search term for safer API requests.