### PR TITLE
feat: hipo button

### DIFF
--- a/apps/frontend/src/components/layout/Navbar.tsx
+++ b/apps/frontend/src/components/layout/Navbar.tsx
@@ -22,6 +22,7 @@ import {
   ChevronRight,
   BarChart3,
   FilePlus,
+  HousePlus,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import NotificationPanel from "@/components/workflow/NotificationPanel";
@@ -270,6 +271,17 @@ export default function Navbar() {
                       <span>Painel Administrativo</span>
                     </Link>
                   )}
+
+                  <Link
+                    href="http://56.124.35.86:8080/"
+                    className="flex items-center px-4 py-2 hover:bg-gray-100"
+                    onClick={(e: any) => {
+                      e.preventDefault();
+                      window.open("http://56.124.35.86:8080/", "_blank");
+                    }}>
+                    <HousePlus className="mr-2" size={16} />
+                    <span>Hipo Saúde</span>
+                  </Link>
                 </div>
               )}
             </div>


### PR DESCRIPTION
This pull request adds a new navigation link to the `Navbar` component, allowing users to open the "Hipo Saúde" page in a new tab. It also includes the addition of the `HousePlus` icon from the `lucide-react` icon set for visual clarity.

**Navigation enhancements:**

* Added a new `Link` in the `Navbar` that opens the "Hipo Saúde" external page (`http://56.124.35.86:8080/`) in a new browser tab, with an associated `HousePlus` icon for better user experience.

**Icon imports:**

* Imported the `HousePlus` icon from `lucide-react` to support the new navigation item.